### PR TITLE
Filter duplicates environment variables

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -93,8 +93,8 @@ main = do
 
   responses <- Async.mapConcurrently (requestSecret opts) secrets
 
-  let newEnvOrError = mapM (uncurry parseResponse) responses
   let
+    newEnvOrError = mapM (uncurry parseResponse) responses
     newEnv = case newEnvOrError of
       -- We need to eliminate duplicates in the environment and keep
       -- the first occurrence. `nubBy` (from Data.List) runs in O(n^2),


### PR DESCRIPTION
We should filter out duplicate environment variables before calling `runCommand` in order to avoid potentially weird behavior when there are duplicates. 

A UNIX process' environment is an array of strings, we don't know how standard libs whatever the users of this library use will react to duplicates. Better safe than sorry.