### PR TITLE
Retry on 5xx response from Vault, log status code

### DIFF
--- a/vaultenv.cabal
+++ b/vaultenv.cabal
@@ -19,6 +19,8 @@ executable vaultenv
                      , http-conduit         >= 2.2    && < 2.3
                      , json-stream          >= 0.4.1  && < 0.4.2
                      , optparse-applicative >= 0.13   && < 0.14
+                     , random               >= 1.1    && < 1.2
                      , text                 >= 1.2    && < 1.3
-                     , unordered-containers >= 0.2    && < 0.3
                      , unix                 >= 2.7    && < 2.8
+                     , unordered-containers >= 0.2    && < 0.3
+                     , utf8-string          >= 1.0    && < 1.1


### PR DESCRIPTION
When Vault returned a non-200 status code, we would still treat the response as a success response and try to parse it. This would lead us to log an "[ERROR] Key 'xxx' not found" message, which is misleading.
This commit changes that, so we only do the parse on a 200 response, and on a non-200 response we log the status code and response body.

Furthermore, add a retry. If Vault returns 500, 503, or 504, then we retry the request at most 2 times, with a random delay in between.

This should make starting our services more resilient.

I have not tested any of this. I am not even sure that the key not found error we are seeing are actually due to 5xx responses. I suspect they are, but at the moment we do not know.