### PR TITLE
Implement exponential backoff with jitter

### DIFF
--- a/vaultenv.cabal
+++ b/vaultenv.cabal
@@ -20,7 +20,7 @@ executable vaultenv
                      , lens                 < 4.16
                      , lens-aeson           < 1.1
                      , optparse-applicative < 0.14
-                     , random               < 1.2
+                     , retry                < 0.8
                      , text                 < 1.3
                      , unordered-containers < 0.3
                      , unix                 < 2.8


### PR DESCRIPTION
This PR implements retrying with an exponential delay instead of a constant. Integration tests are working locally. This should be good to go! (gotta love Haskell)