### PR TITLE
Tls option

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -27,12 +27,13 @@ import qualified Options.Applicative        as O
 --
 
 data Options = Options
-  { oVaultHost   :: String
-  , oVaultPort   :: Int
-  , oVaultToken  :: String
-  , oSecretFile  :: FilePath
-  , oCmd         :: String
-  , oArgs        :: [String]
+  { oVaultHost       :: String
+  , oVaultPort       :: Int
+  , oVaultToken      :: String
+  , oSecretFile      :: FilePath
+  , oCmd             :: String
+  , oArgs            :: [String]
+  , oConnectInsecure :: Bool
   } deriving (Eq, Show)
 
 data Secret = Secret
@@ -84,7 +85,9 @@ optionsParser = Options
        <*> many (argument str
            (  metavar "ARGS..."
            <> help "arguments to pass to CMD, defaults to nothing"))
-
+       <*> switch
+           (  long "no-connect-tls"
+           <> help "don't use TLS when connecting to Vault (default: use TLS)")
 
 -- Adds metadata to the `options` parser so it can be used with
 -- execParser.
@@ -185,6 +188,7 @@ requestSecret opts secret =
             $ setRequestPath (SBS.pack requestPath)
             $ setRequestPort (oVaultPort opts)
             $ setRequestHost (SBS.pack (oVaultHost opts))
+            $ setRequestSecure (not $ oConnectInsecure opts)
             $ defaultRequest
 
     shouldRetry = const $ return . isLeft

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -37,6 +37,7 @@ echo ""
 
 echo "[TEST] Happy path"
 stack exec -- vaultenv \
+  --no-connect-tls \
   --token ${VAULT_TOKEN} \
   --host ${VAULT_HOST} \
   --port ${VAULT_PORT} \
@@ -47,6 +48,7 @@ echo ""
 
 echo "[TEST] Unknown secret, passes if vaultenv errors with secret not found"
 stack exec -- vaultenv \
+  --no-connect-tls \
   --token ${VAULT_TOKEN} \
   --host ${VAULT_HOST} \
   --port ${VAULT_PORT} \
@@ -56,6 +58,7 @@ echo ""
 
 echo "[TEST] Unknown secret key, passes if vaultenv errors with key not found in secret"
 stack exec -- vaultenv \
+  --no-connect-tls \
   --token ${VAULT_TOKEN} \
   --host ${VAULT_HOST} \
   --port ${VAULT_PORT} \
@@ -65,6 +68,7 @@ echo ""
 
 echo "[TEST] Bad token, vaultenv should fail with forbidden"
 stack exec -- vaultenv \
+  --no-connect-tls \
   --token notthevaulttoken \
   --host ${VAULT_HOST} \
   --port ${VAULT_PORT} \
@@ -93,6 +97,7 @@ vault server -config integration-config.hcl &> /dev/null &
 
 echo "[TEST] Vault unavailable. Should error with a corresponding message"
 stack exec -- vaultenv \
+  --no-connect-tls \
   --token notthevaulttoken \
   --host ${VAULT_HOST} \
   --port ${VAULT_PORT} \
@@ -106,6 +111,7 @@ kill %%
 
 echo "[TEST] Vault not running. Should error with a corresponding message"
 stack exec -- vaultenv \
+  --no-connect-tls \
   --token notthevaulttoken \
   --host ${VAULT_HOST} \
   --port ${VAULT_PORT} \


### PR DESCRIPTION
Add `--no-connect-tls` flag wheter they want to connect over TLS or not. vaultenv defaults to connecting over TLS.