### PR TITLE
Mention `stack exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,13 @@ Vaultenv is written in Haskell and builds with [Stack][stack]:
     stack setup
     stack build
 
-The binary can then be found at `$(stack path --local-install-root)/bin/vaultenv`.
+The binary can then be found at `$(stack path
+--local-install-root)/bin/vaultenv`.  You can also run it directly
+with `stack exec`:
+
+```
+stack exec vaultenv -- --token SECRET --secrets-file foo.env /usr/bin/env
+```
 
 It is possible to `stack build` with `--split-objs` to produce a smaller binary.
 To take full advantage of this, the Stackage snapshot has to be rebuilt.


### PR DESCRIPTION
A nice shortcut to running the built binary.

Great project btw! Very similar to a GPG-based tool we use internally that we hadn't expanded to out Vault usage yet. This works very well.