### PR TITLE
Fail if duplicate environment variables are found

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -157,7 +157,7 @@ main = do
       dups (x:xs) | isDup x xs = Left x
                   | otherwise = dups xs
 
-      isDup x = foldr (\y acc -> x == y || acc) False
+      isDup x = foldr (\y acc -> acc || x == y) False
 
 
 parseSecret :: String -> Either String Secret

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -140,8 +140,8 @@ main = do
            Left x -> errorWithoutStackTrace $ "Found duplicate variable \"" ++ x ++ "\""
            _ -> e ++ env
     newEnv = case sequence newEnvOrErrors of
-      -- We need to eliminate duplicates in the environment and keep
-      -- the first occurrence. `nubBy` (from Data.List) runs in O(n^2),
+      -- We need to check duplicates in the environment and fail if
+      -- there are any. `dups` runs in O(n^2),
       -- but this shouldn't matter for our small lists.
       --
       -- Equality is determined on the first element of the env var

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -141,11 +141,16 @@ main = do
       --
       -- Equality is determined on the first element of the env var
       -- tuples.
-      Right e -> nubBy (\(a,_) (b,_) -> a == b) (if oInheritEnvOff opts then e else e ++ env)
+      Right e -> if dups (map fst (e ++ env))
+        then error "Duplicate variable found"
+        else nubBy (\(a,_) (b,_) -> a == b) (if oInheritEnvOff opts then e else e ++ env)
       Left err -> errorWithoutStackTrace (vaultErrorLogMessage err)
 
   runCommand opts newEnv
-
+    where
+      dups :: Eq a => [a] -> Bool
+      dups [] = False
+      dups (x:xs) = foldr ((||) . (x==)) False xs || dups xs
 
 parseSecret :: String -> Either String Secret
 parseSecret line =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -135,10 +135,10 @@ main = do
 
   let
     checkNoDuplicates e =
-      let keys = map fst (e ++ env)
+      let keys = map fst e
       in case dups keys of
            Left x -> errorWithoutStackTrace $ "Found duplicate variable \"" ++ x ++ "\""
-           _ -> e ++ env
+           _ -> e
     newEnv = case sequence newEnvOrErrors of
       -- We need to check duplicates in the environment and fail if
       -- there are any. `dups` runs in O(n^2),

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@ import Control.Lens           (preview)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Char
 import Data.Either            (isLeft)
-import Data.List              (findIndex, nubBy)
+import Data.List              (findIndex)
 import Data.Monoid            ((<>))
 import Network.HTTP.Simple
 import Options.Applicative    hiding (Parser, command)
@@ -137,7 +137,7 @@ main = do
     checkNoDuplicates e =
       let keys = map fst (e ++ env)
       in case dups keys of
-           Left x -> error $ "Found duplicate variable \"" ++ x ++ "\""
+           Left x -> errorWithoutStackTrace $ "Found duplicate variable \"" ++ x ++ "\""
            _ -> e ++ env
     newEnv = case sequence newEnvOrErrors of
       -- We need to eliminate duplicates in the environment and keep
@@ -154,10 +154,10 @@ main = do
     where
       dups :: Eq a => [a] -> Either a ()
       dups [] = Right ()
-      dups (x:xs) | isDup x xs= Left x
+      dups (x:xs) | isDup x xs = Left x
                   | otherwise = dups xs
 
-      isDup x = foldr ((||) . (x==)) False
+      isDup x = foldr (\y acc -> x == y || acc) False
 
 
 parseSecret :: String -> Either String Secret

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -69,6 +69,18 @@ stack exec -- vaultenv \
   | grep -v "HOME"
 echo ""
 
+echo "[TEST] Duplicate environment variable, vaultenv should fail with duplicate env variable"
+export TESTING_KEY=testing666
+stack exec -- vaultenv \
+      --no-connect-tls \
+      --token ${VAULT_TOKEN} \
+      --host ${VAULT_HOST} \
+      --port ${VAULT_PORT} \
+      --secrets-file ./integration.secrets \
+      /usr/bin/env
+unset TESTING_KEY
+echo ""
+
 echo "[TEST] Unknown secret, passes if vaultenv errors with secret not found"
 stack exec -- vaultenv \
   --no-connect-tls \


### PR DESCRIPTION
Fixes #5 

In the issue the options mentioned are failing or printing a warning: I leaned towards the former since overriding a variable name is most of the times something done by accident in my experience. But let me know what you folks think about it, if you have a different opinion it won't take much work to change the PR.

The time complexity of `dups` is still quadratic but since that wasn't seen as a performance issue before I didn't use a better one.
