### PR TITLE
Disable environment inheritance config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Available options:
   --port PORT              Vault port, defaults to 8200
   --token TOKEN            token to authenticate to Vault with
   --secrets-file FILENAME  config file specifying which secrets to request
+  --no-env-inheritance     don't merge the current environment with the secret
   CMD                      command to run after fetching secrets
   ARGS...                  arguments to pass to CMD, defaults to nothing
   -h,--help                Show this help text

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -34,6 +34,7 @@ data Options = Options
   , oCmd             :: String
   , oArgs            :: [String]
   , oConnectInsecure :: Bool
+  , oInheritEnvOff   :: Bool
   } deriving (Eq, Show)
 
 data Secret = Secret
@@ -88,6 +89,9 @@ optionsParser = Options
        <*> switch
            (  long "no-connect-tls"
            <> help "don't use TLS when connecting to Vault (default: use TLS)")
+       <*> switch
+           (  long "no-env-inheritance"
+           <> help "don't merge the parent environment with the secrets file")
 
 -- Adds metadata to the `options` parser so it can be used with
 -- execParser.
@@ -137,7 +141,7 @@ main = do
       --
       -- Equality is determined on the first element of the env var
       -- tuples.
-      Right e -> nubBy (\(a,_) (b,_) -> a == b) (e ++ env)
+      Right e -> nubBy (\(a,_) (b,_) -> a == b) (if oInheritEnvOff opts then e else e ++ env)
       Left err -> errorWithoutStackTrace (vaultErrorLogMessage err)
 
   runCommand opts newEnv


### PR DESCRIPTION
Fixes #14 

I named the new config option `no-env-inheritance` but ready to change it if anyone has a better alternative.

PS: this PR and https://github.com/channable/vaultenv/pull/19 will cause merge conflicts