### PR TITLE
Added netbase package

### DIFF
--- a/package/deb_control
+++ b/package/deb_control
@@ -7,4 +7,5 @@ Description: Run processes with secrets from HashiCorp Vault
 Depends: libc6,
          libgmp10,
          libgcc1,
-         zlib1g
+         zlib1g,
+         netbase


### PR DESCRIPTION
I've faced with issue running vaultenv in Docker containers, on official Ubuntu images. The error was:
```
vaultenv: [ERROR] Network trouble. Host can be unreachable, requests may be timing out or DNS not working.
```
The file `/etc/protocols` is absent in image, and it providing by `netbase` package. I think it would nice to have this package in dependencies. 

Strace output:
```
[pid   486] open("/etc/protocols", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
[pid   486] write(22, "\1\0\0\0\0\0\0\0", 8) = 8
[pid   485] <... poll resumed> )        = 1 ([{fd=22, revents=POLLIN}])
[pid   485] read(22,  <unfinished ...>
[pid   486] getrusage(RUSAGE_SELF,  <unfinished ...>
[pid   485] <... read resumed> "\1\0\0\0\0\0\0\0", 8) = 8
[pid   486] <... getrusage resumed> {ru_utime={0, 0}, ru_stime={0, 10000}, ...}) = 0
[pid   485] poll([{fd=18, events=POLLIN}, {fd=22, events=POLLIN}], 2, 4987 <unfinished ...>
[pid   486] write(22, "\1\0\0\0\0\0\0\0", 8) = 8
[pid   485] <... poll resumed> )        = 1 ([{fd=22, revents=POLLIN}])
[pid   486] futex(0x7f004c00091c, FUTEX_WAIT_PRIVATE, 5, NULL <unfinished ...>
[pid   485] read(22, "\1\0\0\0\0\0\0\0", 8) = 8
```
