### PR TITLE
Option for retry-base-delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Available options:
   --secrets-file FILENAME  config file specifying which secrets to request
   --no-connect-tls         don't use TLS when connecting to Vault
   --no-inherit-env         don't merge the current environment with the secret
+  --retry-base-delay-milliseconds MILLISECONDS
+                           base delay for vault connection retrying. Defaults to
+                           40ms because, in testing, we found out that fetching
+                           50 secrets takes roughly 200 milliseconds
+  --retry-attempts NUM     maximum number of vault connection retries. Defaults
+                           to 9
   CMD                      command to run after fetching secrets
   ARGS...                  arguments to pass to CMD, defaults to nothing
   -h,--help                Show this help text

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -113,7 +113,7 @@ optionsParser env = Options
            (  long "no-inherit-env"
            <> help "don't merge the parent environment with the secrets file")
        <*> (MilliSeconds <$> option auto
-               (  long "retry-base-delay"
+               (  long "retry-base-delay-milliseconds"
                <> metavar "MILLISECONDS"
                <> value (40 :: Int)
                <> help "base delay for vault connection retrying. Defaults to 40ms because, in testing, we found out that fetching 50 secrets takes roughly 200 milliseconds"))


### PR DESCRIPTION
Makes the base delay for the vault exponential backoff reconnection
strategy configurable, as requested in #11.