### PR TITLE
Add option to skip cert validation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -293,8 +293,8 @@ requestSecret context secretPath =
 requestSecrets :: Context -> [Secret] -> (ExceptT VaultError IO) [EnvVar]
 requestSecrets context secrets = do
   let secretPaths = Foldable.foldMap (\x -> Map.singleton x x) $ fmap sPath secrets
-  esecretData <- liftIO $ Async.mapConcurrently (requestSecret context) secretPaths
-  either throwError return $ sequence esecretData >>= lookupSecrets secrets
+  secretDataOrErr <- liftIO $ Async.mapConcurrently (requestSecret context) secretPaths
+  either throwError return $ sequence secretDataOrErr >>= lookupSecrets secrets
 
 -- | Look for the requested keys in the secret data that has been previously fetched.
 lookupSecrets :: [Secret] -> Map.Map String VaultData -> Either VaultError [EnvVar]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -190,7 +190,15 @@ getHttpManager opts = newManager managerSettings
                 , settingUseServerName = True
                 }
 
-vaultEnv :: Context -> (ExceptT VaultError IO) [EnvVar]
+-- | Main logic of our application. Reads a list of secrets, fetches
+-- each of them from Vault, checks for duplicates, and then yields
+-- the list of environment variables to make available to the process
+-- we want to run eventually. It either scrubs the environment that
+-- already existed or keeps it.
+--
+-- Signails failure through a value of type VaultError, but can also
+-- throw HTTP exceptions.
+vaultEnv :: Context -> ExceptT VaultError IO [EnvVar]
 vaultEnv context = do
   secrets <- readSecretList (oSecretFile . cCliOptions $ context)
   secretEnv <- requestSecrets context secrets

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,17 +5,21 @@
 import Control.Monad          (forM)
 import Control.Lens           (reindexed, to)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Char
+import Data.Char              (toUpper)
 import Data.Either            (isLeft)
 import Data.List              (findIndex, lookup)
 import Data.Monoid            ((<>))
 import Network.Connection     (TLSSettings(..))
 import Network.HTTP.Client    (defaultManagerSettings)
 import Network.HTTP.Conduit   (Manager, newManager, mkManagerSettings)
-import Network.HTTP.Simple
+import Network.HTTP.Simple    (HttpException(..), Request, Response,
+                               defaultRequest, setRequestHeader, setRequestPort,
+                               setRequestPath, setRequestHost, setRequestManager,
+                               setRequestSecure, httpLBS, getResponseBody,
+                               getResponseStatusCode)
 import Options.Applicative    hiding (Parser, command)
-import System.Environment
-import System.Posix.Process
+import System.Environment     (getEnvironment)
+import System.Posix.Process   (executeFile)
 import System.IO              (stderr, hPutStrLn)
 import Control.Monad.Except   (ExceptT, MonadError, runExceptT, throwError)
 

--- a/package.yaml
+++ b/package.yaml
@@ -13,8 +13,10 @@ executables:
       - base < 5
       - async
       - bytestring
+      - connection
       - containers
       - http-conduit
+      - http-client
       - lens
       - lens-aeson
       - optparse-applicative

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-9.5
+resolver: lts-10.5


### PR DESCRIPTION
This PR adds a new CLI option `--no-validate-certs` to vaultenv. It addresses #34 

Still needs an integration test, but I have verified this locally