### PR TITLE
Configuration via environment variables

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -95,6 +95,7 @@ main :: IO ()
 main = do
   localEnvVars <- getEnvironment
   cliAndEnvOptions <- parseOptionsFromEnvAndCli localEnvVars
+  print cliAndEnvOptions
 
   httpManager <- getHttpManager cliAndEnvOptions
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -131,18 +131,39 @@ optionsParser envSwitches environment = Options
     <*> many (argument str
       (  metavar "ARGS..."
       <> help "Arguments to pass to CMD, defaults to nothing"))
-    <*> flag (esNoConnectTls envSwitches) True
-      (  long "no-connect-tls"
-      <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
-               "configurable via VAULTENV_NO_CONNECT_TLS."))
-    <*> flag (esNoValidateCerts envSwitches) True
-      (  long "no-validate-certs"
-      <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
-               "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS."))
-    <*> flag (esNoInheritEnv envSwitches) True
-      (  long "no-inherit-env"
-      <> help ("Don't merge the parent environment with the secrets file. Default: " ++
-               "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV."))
+    <*>
+      ( flag (esNoConnectTls envSwitches) True
+        (  long "no-connect-tls"
+        <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
+                "configurable via VAULTENV_NO_CONNECT_TLS."))
+      <|> flag (esNoConnectTls envSwitches) False
+        (  long "connect-tls"
+        <> help ("Always connect to Vault via TLS. Default: use TLS. Can be used " ++
+                 "to override VAULTENV_NO_CONNECT_TLS.")
+        )
+      )
+    <*>
+      ( flag (esNoValidateCerts envSwitches) True
+        (  long "no-validate-certs"
+        <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
+                "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS."))
+      <|> flag (esNoValidateCerts envSwitches) False
+        (  long "validate-certs"
+        <> help ("Always validate TLS certificates when connecting to Vault. Default: " ++
+                 "validate certs. Can be used to override VAULTENV_NO_CONNECT_TLS.")
+        )
+      )
+    <*>
+      ( flag (esNoInheritEnv envSwitches) True
+        (  long "no-inherit-env"
+        <> help ("Don't merge the parent environment with the secrets file. Default: " ++
+                "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV."))
+      <|> flag (esNoInheritEnv envSwitches) False
+        (  long "inherit-env"
+        <> help ("Always merge the parent environment with the secrets file. Default: " ++
+                 "merge environments. Can be used to override VAULTENV_NO_INHERIT_ENV.")
+        )
+      )
     <*> (MilliSeconds <$> option auto
             (  long "retry-base-delay-milliseconds"
             <> metavar "MILLISECONDS"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,10 +2,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
---
--- Stackage and stdlib
---
-
 import Control.Monad          (forM)
 import Control.Lens           (reindexed, to)
 import Control.Monad.IO.Class (MonadIO, liftIO)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,12 +2,16 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+--
+-- Stackage and stdlib
+--
+
 import Control.Monad          (forM)
 import Control.Lens           (reindexed, to)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Char              (toUpper)
 import Data.Either            (isLeft)
-import Data.List              (findIndex, lookup)
+import Data.List              (findIndex)
 import Data.Monoid            ((<>))
 import Network.Connection     (TLSSettings(..))
 import Network.HTTP.Client    (defaultManagerSettings)
@@ -17,7 +21,6 @@ import Network.HTTP.Simple    (HttpException(..), Request, Response,
                                setRequestPath, setRequestHost, setRequestManager,
                                setRequestSecure, httpLBS, getResponseBody,
                                getResponseStatusCode)
-import Options.Applicative    hiding (Parser, command)
 import System.Environment     (getEnvironment)
 import System.Posix.Process   (executeFile)
 import System.IO              (stderr, hPutStrLn)
@@ -35,32 +38,16 @@ import qualified Data.Foldable              as Foldable
 import qualified Data.Map                   as Map
 import qualified Data.Map.Lens              as Lens (toMapOf)
 import qualified Data.Text                  as Text
-import qualified Options.Applicative        as O
-import qualified Text.Read as Read
+
+--
+-- Internal imports
+--
+
+import Config
 
 --
 -- Datatypes
 --
-
-data Options = Options
-  { oVaultHost       :: String
-  , oVaultPort       :: Int
-  , oVaultToken      :: String
-  , oSecretFile      :: FilePath
-  , oCmd             :: String
-  , oArgs            :: [String]
-  , oNoConnectTls    :: Bool
-  , oNoValidateCerts :: Bool
-  , oNoInheritEnv    :: Bool
-  , oRetryBaseDelay  :: MilliSeconds
-  , oRetryAttempts   :: Int
-  } deriving (Eq, Show)
-
-data EnvSwitches = EnvSwitches
-  { esNoConnectTls :: Bool
-  , esNoValidateCerts :: Bool
-  , esNoInheritEnv :: Bool
-  }
 
 data Secret = Secret
   { sPath    :: String
@@ -93,150 +80,6 @@ data VaultError
   | DuplicateVar      String
   | Unspecified       Int LBS.ByteString
 
-newtype MilliSeconds = MilliSeconds { unMilliSeconds :: Int }
-  deriving (Eq, Show)
-
---
--- Argument parsing
---
-
--- | Parser for our CLI options. Seems intimidating, but is straightforward
--- once you know about applicative parsing patterns. We construct a parser for
--- @Options@ by concatenating parsers for parts of the record.
---
--- Toy example to illustrate the pattern:
---
--- @
---     OptionRecord <$> parser1 <*> parser2 <*> parser3
--- @
---
--- Here, the parser for @OptionRecord@ is the combination of parsers of it's
--- internal fields.
---
--- The parsers get constructed by using different combinators from the
--- @Options.Applicative@ module. Here, we use @strOption@, @option@, @argument@
--- and flag. These take a @Mod@ value, which can specify how to parse an
--- option. These @Mod@ values have monoid instances and are composed as such.
---
--- So in our example above, we could have the following definition for
--- @parser1@:
---
--- @
---    parser1 = strOption $ long "my-option" <> value "default"
--- @
---
--- And have the thing compile if the first member of @OptionRecord@ would have
--- type @String@.
-optionsParser :: EnvSwitches -> [EnvVar] -> O.Parser Options
-optionsParser envSwitches environment = Options
-    <$> strOption
-      (  long "host"
-      <> metavar "HOST"
-      <> value "localhost"
-      <> lookupFromEnv "VAULT_HOST"
-      <> help ("Vault host, either an IP address or DNS name. Defaults to localhost. " ++
-               "Also configurable via VAULT_HOST."))
-    <*> option auto
-      (  long "port"
-      <> metavar "PORT"
-      <> lookupFromEnvWithDefault "VAULT_PORT" 8200
-      <> help "Vault port. Defaults to 8200. Also configurable via VAULT_PORT." )
-    <*> strOption
-      (  long "token"
-      <> metavar "TOKEN"
-      <> lookupFromEnv "VAULT_TOKEN"
-      <> help "Token to authenticate to Vault with. Also configurable via VAULT_TOKEN.")
-    <*> strOption
-      (  long "secrets-file"
-      <> metavar "FILENAME"
-      <> lookupFromEnv "VAULTENV_SECRETS_FILE"
-      <> help ("Config file specifying which secrets to request. Also configurable " ++
-               "via VAULTENV_SECRETS_FILE." ))
-    <*> argument str
-      (  metavar "CMD"
-      <> help "command to run after fetching secrets")
-    <*> many (argument str
-      (  metavar "ARGS..."
-      <> help "Arguments to pass to CMD, defaults to nothing"))
-    <*>
-      ( flag (esNoConnectTls envSwitches) True
-        (  long "no-connect-tls"
-        <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
-                "configurable via VAULTENV_NO_CONNECT_TLS."))
-      <|> flag (esNoConnectTls envSwitches) False
-        (  long "connect-tls"
-        <> help ("Always connect to Vault via TLS. Default: use TLS. Can be used " ++
-                 "to override VAULTENV_NO_CONNECT_TLS.")
-        )
-      )
-    <*>
-      ( flag (esNoValidateCerts envSwitches) True
-        (  long "no-validate-certs"
-        <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
-                "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS."))
-      <|> flag (esNoValidateCerts envSwitches) False
-        (  long "validate-certs"
-        <> help ("Always validate TLS certificates when connecting to Vault. Default: " ++
-                 "validate certs. Can be used to override VAULTENV_NO_CONNECT_TLS.")
-        )
-      )
-    <*>
-      ( flag (esNoInheritEnv envSwitches) True
-        (  long "no-inherit-env"
-        <> help ("Don't merge the parent environment with the secrets file. Default: " ++
-                "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV."))
-      <|> flag (esNoInheritEnv envSwitches) False
-        (  long "inherit-env"
-        <> help ("Always merge the parent environment with the secrets file. Default: " ++
-                 "merge environments. Can be used to override VAULTENV_NO_INHERIT_ENV.")
-        )
-      )
-    <*> (MilliSeconds <$> option auto
-            (  long "retry-base-delay-milliseconds"
-            <> metavar "MILLISECONDS"
-            <> lookupFromEnvWithDefault "VAULTENV_RETRY_BASE_DELAY_MS" 40
-            <> help ("Base delay for vault connection retrying. Defaults to 40ms. " ++
-                     "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS.")))
-    <*> option auto
-      (  long "retry-attempts"
-      <> metavar "NUM"
-      <> lookupFromEnvWithDefault "VAULTENV_RETRY_ATTEMPTS" 9
-      <> help "Maximum number of vault connection retries. Defaults to 9")
-  where
-    lookupFromEnv key = foldMap value (lookup key environment)
-    lookupFromEnvWithDefault key defVal = maybe (value defVal) value (readFromEnvironment key)
-
-    readFromEnvironment :: Read a => String -> Maybe a
-    readFromEnvironment var = lookup var environment >>= Read.readMaybe
-
--- | Add metadata to the `options` parser so it can be used with execParser.
-optionsInfo :: EnvSwitches -> [EnvVar] -> ParserInfo Options
-optionsInfo envSwitches localEnvVars =
-  info
-    (optionsParser envSwitches localEnvVars <**> helper)
-    (fullDesc <> header "vaultenv - run programs with secrets from HashiCorp Vault")
-
--- | Parses behaviour switches from a list of environment variables. If an
--- environment variable corresponding to the flag is set to @"true"@ or
--- @"false"@, we use that as the default on the corresponding CLI option.
---
--- If these variables aren't present, we default to @False@. We print an error
--- if they're set to anything else than @"true"@ or @"false"@.
-parseEnvSwitches :: [EnvVar] -> EnvSwitches
-parseEnvSwitches vars
-  = EnvSwitches
-  { esNoConnectTls = envSwitch "VAULTENV_NO_CONNECT_TLS"
-  , esNoValidateCerts = envSwitch "VAULTENV_NO_VALIDATE_CERTS"
-  , esNoInheritEnv = envSwitch "VAULTENV_NO_INHERIT_ENV"
-  }
-  where
-    envSwitch key =
-      case lookup key vars of
-        Just "true" -> True
-        Just "false" -> False
-        Nothing -> False
-        _ -> errorWithoutStackTrace $ "[ERROR]: Invalid value for environment variable " ++ key
-
 -- | Retry configuration to use for network requests to Vault.
 -- We use a limited exponential backoff with the policy
 -- fullJitterBackoff that comes with the Retry package.
@@ -251,10 +94,7 @@ vaultRetryPolicy opts = Retry.fullJitterBackoff (unMilliSeconds (oRetryBaseDelay
 main :: IO ()
 main = do
   localEnvVars <- getEnvironment
-
-  cliAndEnvOptions <- execParser (optionsInfo (parseEnvSwitches localEnvVars) localEnvVars)
-
-  print cliAndEnvOptions
+  cliAndEnvOptions <- parseOptionsFromEnvAndCli localEnvVars
 
   httpManager <- getHttpManager cliAndEnvOptions
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -102,52 +102,58 @@ newtype MilliSeconds = MilliSeconds { unMilliSeconds :: Int }
 
 optionsParser :: EnvSwitches -> [EnvVar] -> O.Parser Options
 optionsParser envSwitches environment = Options
-       <$> strOption
-           (  long "host"
-           <> metavar "HOST"
-           <> lookupFromEnv "VAULT_HOST"
-           <> value "localhost"
-           <> help "Vault host, either an IP address or DNS name, defaults to localhost" )
-       <*> option auto
-           (  long "port"
-           <> metavar "PORT"
-           <> lookupFromEnvWithDefault "VAULT_PORT" 8200
-           <> help "Vault port, defaults to 8200" )
-       <*> strOption
-           (  long "token"
-           <> metavar "TOKEN"
-           <> lookupFromEnv "VAULT_TOKEN"
-           <> help "token to authenticate to Vault with, defaults to the value of the VAULT_TOKEN environment variable if present")
-       <*> strOption
-           (  long "secrets-file"
-           <> metavar "FILENAME"
-           <> lookupFromEnv "VAULTENV_SECRETS_FILE"
-           <> help "config file specifying which secrets to request" )
-       <*> argument str
-           (  metavar "CMD"
-           <> help "command to run after fetching secrets")
-       <*> many (argument str
-           (  metavar "ARGS..."
-           <> help "arguments to pass to CMD, defaults to nothing"))
-       <*> flag (esNoConnectTls envSwitches) True
-           (  long "no-connect-tls"
-           <> help "don't use TLS when connecting to Vault (default: use TLS)")
-       <*> flag (esNoValidateCerts envSwitches) True
-           (  long "no-validate-certs"
-           <> help "don't validate TLS certificates when connecting to Vault (default: validate certs)")
-       <*> flag (esNoInheritEnv envSwitches) True
-           (  long "no-inherit-env"
-           <> help "don't merge the parent environment with the secrets file")
-       <*> (MilliSeconds <$> option auto
-               (  long "retry-base-delay-milliseconds"
-               <> metavar "MILLISECONDS"
-               <> lookupFromEnvWithDefault "VAULTENV_RETRY_BASE_DELAY_MS" 40
-               <> help "base delay for vault connection retrying. Defaults to 40ms because, in testing, we found out that fetching 50 secrets takes roughly 200 milliseconds"))
-       <*> option auto
-           (  long "retry-attempts"
-           <> metavar "NUM"
-           <> lookupFromEnvWithDefault "VAULTENV_RETRY_ATTEMPTS" 9
-           <> help "maximum number of vault connection retries. Defaults to 9")
+    <$> strOption
+      (  long "host"
+      <> metavar "HOST"
+      <> value "localhost"
+      <> lookupFromEnv "VAULT_HOST"
+      <> help ("Vault host, either an IP address or DNS name. Defaults to localhost. " ++
+               "Also configurable via VAULT_HOST."))
+    <*> option auto
+      (  long "port"
+      <> metavar "PORT"
+      <> lookupFromEnvWithDefault "VAULT_PORT" 8200
+      <> help "Vault port. Defaults to 8200. Also configurable via VAULT_PORT." )
+    <*> strOption
+      (  long "token"
+      <> metavar "TOKEN"
+      <> lookupFromEnv "VAULT_TOKEN"
+      <> help "Token to authenticate to Vault with. Also configurable via VAULT_TOKEN.")
+    <*> strOption
+      (  long "secrets-file"
+      <> metavar "FILENAME"
+      <> lookupFromEnv "VAULTENV_SECRETS_FILE"
+      <> help ("Config file specifying which secrets to request. Also configurable " ++
+               "via VAULTENV_SECRETS_FILE." ))
+    <*> argument str
+      (  metavar "CMD"
+      <> help "command to run after fetching secrets")
+    <*> many (argument str
+      (  metavar "ARGS..."
+      <> help "Arguments to pass to CMD, defaults to nothing"))
+    <*> flag (esNoConnectTls envSwitches) True
+      (  long "no-connect-tls"
+      <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
+               "configurable via VAULTENV_NO_CONNECT_TLS."))
+    <*> flag (esNoValidateCerts envSwitches) True
+      (  long "no-validate-certs"
+      <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
+               "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS."))
+    <*> flag (esNoInheritEnv envSwitches) True
+      (  long "no-inherit-env"
+      <> help ("Don't merge the parent environment with the secrets file. Default: " ++
+               "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV."))
+    <*> (MilliSeconds <$> option auto
+            (  long "retry-base-delay-milliseconds"
+            <> metavar "MILLISECONDS"
+            <> lookupFromEnvWithDefault "VAULTENV_RETRY_BASE_DELAY_MS" 40
+            <> help ("Base delay for vault connection retrying. Defaults to 40ms. " ++
+                     "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS.")))
+    <*> option auto
+      (  long "retry-attempts"
+      <> metavar "NUM"
+      <> lookupFromEnvWithDefault "VAULTENV_RETRY_ATTEMPTS" 9
+      <> help "Maximum number of vault connection retries. Defaults to 9")
   where
     lookupFromEnv key = foldMap value (lookup key environment)
     lookupFromEnvWithDefault key defVal = maybe (value defVal) value (readFromEnvironment key)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -100,6 +100,33 @@ newtype MilliSeconds = MilliSeconds { unMilliSeconds :: Int }
 -- Argument parsing
 --
 
+-- | Parser for our CLI options. Seems intimidating, but is straightforward
+-- once you know about applicative parsing patterns. We construct a parser for
+-- @Options@ by concatenating parsers for parts of the record.
+--
+-- Toy example to illustrate the pattern:
+--
+-- @
+--     OptionRecord <$> parser1 <*> parser2 <*> parser3
+-- @
+--
+-- Here, the parser for @OptionRecord@ is the combination of parsers of it's
+-- internal fields.
+--
+-- The parsers get constructed by using different combinators from the
+-- @Options.Applicative@ module. Here, we use @strOption@, @option@, @argument@
+-- and flag. These take a @Mod@ value, which can specify how to parse an
+-- option. These @Mod@ values have monoid instances and are composed as such.
+--
+-- So in our example above, we could have the following definition for
+-- @parser1@:
+--
+-- @
+--    parser1 = strOption $ long "my-option" <> value "default"
+-- @
+--
+-- And have the thing compile if the first member of @OptionRecord@ would have
+-- type @String@.
 optionsParser :: EnvSwitches -> [EnvVar] -> O.Parser Options
 optionsParser envSwitches environment = Options
     <$> strOption

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -95,7 +95,6 @@ main :: IO ()
 main = do
   localEnvVars <- getEnvironment
   cliAndEnvOptions <- parseOptionsFromEnvAndCli localEnvVars
-  print cliAndEnvOptions
 
   httpManager <- getHttpManager cliAndEnvOptions
 

--- a/package.yaml
+++ b/package.yaml
@@ -6,6 +6,21 @@ github: channable/vaultenv
 
 dependencies:
   - base
+  - async
+  - bytestring
+  - connection
+  - containers
+  - http-conduit
+  - http-client
+  - lens
+  - lens-aeson
+  - mtl
+  - optparse-applicative
+  - retry
+  - text
+  - unordered-containers
+  - unix
+  - utf8-string
   - optparse-applicative
 
 library:
@@ -17,20 +32,4 @@ executables:
     source-dirs: app
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
     dependencies:
-      - base < 5
-      - async
-      - bytestring
-      - connection
-      - containers
-      - http-conduit
-      - http-client
-      - lens
-      - lens-aeson
-      - mtl
-      - optparse-applicative
-      - retry
-      - text
-      - unordered-containers
-      - unix
-      - utf8-string
       - vaultenv

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,8 @@ dependencies:
   - utf8-string
   - optparse-applicative
 
+ghc-options: -Wall -Werror
+
 library:
   source-dirs: src
 
@@ -30,6 +32,6 @@ executables:
   vaultenv:
     main: Main.hs
     source-dirs: app
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N
     dependencies:
       - vaultenv

--- a/package.yaml
+++ b/package.yaml
@@ -4,6 +4,13 @@ synopsis: Runs processes with secrets from HashiCorp Vault
 license: BSD3
 github: channable/vaultenv
 
+dependencies:
+  - base
+  - optparse-applicative
+
+library:
+  source-dirs: src
+
 executables:
   vaultenv:
     main: Main.hs
@@ -19,10 +26,11 @@ executables:
       - http-client
       - lens
       - lens-aeson
+      - mtl
       - optparse-applicative
       - retry
       - text
       - unordered-containers
       - unix
       - utf8-string
-      - mtl
+      - vaultenv

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -54,7 +54,7 @@ parseOptionsFromEnvAndCli envVars =
       parser = optionsParserWithInfo envFlags envVars
   in OptParse.execParser parser
 
--- | Parses behaviour switches from a list of environment variables. If an
+-- | Parses behaviour flags from a list of environment variables. If an
 -- environment variable corresponding to the flag is set to @"true"@ or
 -- @"false"@, we use that as the default on the corresponding CLI option.
 --
@@ -110,6 +110,13 @@ optionsParserWithInfo envFlags localEnvVars =
 --
 -- And have the thing compile if the first member of @OptionRecord@ would have
 -- type @String@.
+--
+-- Another thing that should be noted is the way we use the Alternate instance
+-- of Parsers in order to provide dual options. The @noConnectTls@,
+-- @noValidateCerts@ and @noInheritEnv@ parsers constist of two parts. One for
+-- the affirmative and one for the negative case. This is required so
+-- we can override environment variables, since optparse-applicative does not
+-- provide an abstraction for this by itself.
 optionsParser :: EnvFlags -> [EnvVar] -> OptParse.Parser Options
 optionsParser envFlags envVars = Options
     <$> host

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -8,7 +8,7 @@ import Control.Applicative ((<*>), (<|>))
 import Data.Monoid ((<>))
 
 import Options.Applicative (value, long, auto, option, metavar, help, flag,
-                            str, argument, many, strOption, (<**>))
+                            str, argument, many, strOption)
 
 import qualified Options.Applicative as OptParse
 import qualified Options.Applicative.Builder.Internal as OptParse

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -22,7 +22,7 @@ newtype MilliSeconds = MilliSeconds { unMilliSeconds :: Int }
   deriving (Eq, Show)
 
 -- | @Options@ contains all the configuration we support in vaultenv. It is
--- used in our @Main@ module to specify behaviour.
+-- used in our @Main@ module to specify behavior.
 data Options = Options
   { oVaultHost       :: String
   , oVaultPort       :: Int
@@ -37,7 +37,7 @@ data Options = Options
   , oRetryAttempts   :: Int
   } deriving (Eq, Show)
 
--- | Behaviour flags that we allow users to set via environment variables.
+-- | Behavior flags that we allow users to set via environment variables.
 -- This type is internal to the workings of this module. It is used as an
 -- intermediate value to get optparse-applicative to play nice with environment
 -- variables as used for behavior flags.
@@ -54,7 +54,7 @@ parseOptionsFromEnvAndCli envVars =
       parser = optionsParserWithInfo envFlags envVars
   in OptParse.execParser parser
 
--- | Parses behaviour flags from a list of environment variables. If an
+-- | Parses behavior flags from a list of environment variables. If an
 -- environment variable corresponding to the flag is set to @"true"@ or
 -- @"false"@, we use that as the default on the corresponding CLI option.
 --

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -14,10 +14,10 @@ import qualified Options.Applicative as OptParse
 import qualified Options.Applicative.Builder.Internal as OptParse
 import qualified Text.Read as Read
 
--- ! Type alias for enviornment variables, used for readability in this module.
+-- | Type alias for enviornment variables, used for readability in this module.
 type EnvVar = (String, String)
 
--- ! Newtype wrapper for millisecond values.
+-- | Newtype wrapper for millisecond values.
 newtype MilliSeconds = MilliSeconds { unMilliSeconds :: Int }
   deriving (Eq, Show)
 
@@ -210,7 +210,7 @@ optionsParser envFlags envVars = Options
       <> readValueFromEnvWithDefault "VAULTENV_RETRY_ATTEMPTS" 9 envVars
       <> help "Maximum number of vault connection retries. Defaults to 9"
 
--- ! Attempt to parse an optparse default value modifier from a list of
+-- | Attempt to parse an optparse default value modifier from a list of
 -- environment variables. This function returns an empty option modifier in
 -- case the environment variable is missing or does not parse.
 readValueFromEnv :: (Read a, OptParse.HasValue f)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,0 +1,184 @@
+module Config
+  ( Options(..)
+  , MilliSeconds(..)
+  , parseOptionsFromEnvAndCli
+  ) where
+
+import Control.Applicative ((<*>), (<|>))
+import Data.Monoid ((<>))
+
+import Options.Applicative (value, long, auto, option, metavar, help, flag, str, argument, many, strOption, (<**>))
+
+import qualified Options.Applicative as OptParse
+import qualified Text.Read as Read
+
+type EnvVar = (String, String)
+
+newtype MilliSeconds = MilliSeconds { unMilliSeconds :: Int }
+  deriving (Eq, Show)
+
+data Options = Options
+  { oVaultHost       :: String
+  , oVaultPort       :: Int
+  , oVaultToken      :: String
+  , oSecretFile      :: FilePath
+  , oCmd             :: String
+  , oArgs            :: [String]
+  , oNoConnectTls    :: Bool
+  , oNoValidateCerts :: Bool
+  , oNoInheritEnv    :: Bool
+  , oRetryBaseDelay  :: MilliSeconds
+  , oRetryAttempts   :: Int
+  } deriving (Eq, Show)
+
+-- | Behaviour flags that we allow users to set via environment variables.
+-- This type is internal to the workings of this module.
+data EnvFlags = EnvFlags
+  { efNoConnectTls :: Bool
+  , efNoValidateCerts :: Bool
+  , efNoInheritEnv :: Bool
+  }
+
+-- | Parse program options from the command line and the process environment.
+parseOptionsFromEnvAndCli :: [EnvVar] -> IO Options
+parseOptionsFromEnvAndCli envVars =
+  let envFlags = parseEnvFlags envVars
+      parser = optionsParserWithInfo envFlags envVars
+  in OptParse.execParser parser
+
+-- | Parses behaviour switches from a list of environment variables. If an
+-- environment variable corresponding to the flag is set to @"true"@ or
+-- @"false"@, we use that as the default on the corresponding CLI option.
+--
+-- If these variables aren't present, we default to @False@. We print an error
+-- if they're set to anything else than @"true"@ or @"false"@.
+parseEnvFlags :: [EnvVar] -> EnvFlags
+parseEnvFlags envVars
+  = EnvFlags
+  { efNoConnectTls = lookupEnvFlag "VAULTENV_NO_CONNECT_TLS"
+  , efNoValidateCerts = lookupEnvFlag "VAULTENV_NO_VALIDATE_CERTS"
+  , efNoInheritEnv = lookupEnvFlag "VAULTENV_NO_INHERIT_ENV"
+  }
+  where
+    lookupEnvFlag key =
+      case lookup key envVars of
+        Just "true" -> True
+        Just "false" -> False
+        Nothing -> False
+        _ -> errorWithoutStackTrace $ "[ERROR]: Invalid value for environment variable " ++ key
+
+-- | Add metadata to the @Options@ parser so it can be used with execParser.
+optionsParserWithInfo :: EnvFlags -> [EnvVar] -> OptParse.ParserInfo Options
+optionsParserWithInfo envFlags localEnvVars =
+  OptParse.info
+    (optionsParser envFlags localEnvVars <**> OptParse.helper)
+    (OptParse.fullDesc <> OptParse.header "vaultenv - run programs with secrets from HashiCorp Vault")
+
+-- | Parser for our CLI options. Seems intimidating, but is straightforward
+-- once you know about applicative parsing patterns. We construct a parser for
+-- @Options@ by concatenating parsers for parts of the record.
+--
+-- Toy example to illustrate the pattern:
+--
+-- @
+--     OptionRecord <$> parser1 <*> parser2 <*> parser3
+-- @
+--
+-- Here, the parser for @OptionRecord@ is the combination of parsers of it's
+-- internal fields.
+--
+-- The parsers get constructed by using different combinators from the
+-- @Options.Applicative@ module. Here, we use @strOption@, @option@, @argument@
+-- and flag. These take a @Mod@ value, which can specify how to parse an
+-- option. These @Mod@ values have monoid instances and are composed as such.
+--
+-- So in our example above, we could have the following definition for
+-- @parser1@:
+--
+-- @
+--    parser1 = strOption $ long "my-option" <> value "default"
+-- @
+--
+-- And have the thing compile if the first member of @OptionRecord@ would have
+-- type @String@.
+optionsParser :: EnvFlags -> [EnvVar] -> OptParse.Parser Options
+optionsParser envFlags envVars = Options
+    <$> strOption
+      (  long "host"
+      <> metavar "HOST"
+      <> value "localhost"
+      <> lookupFromEnv "VAULT_HOST"
+      <> help ("Vault host, either an IP address or DNS name. Defaults to localhost. " ++
+               "Also configurable via VAULT_HOST."))
+    <*> option auto
+      (  long "port"
+      <> metavar "PORT"
+      <> lookupFromEnvWithDefault "VAULT_PORT" 8200
+      <> help "Vault port. Defaults to 8200. Also configurable via VAULT_PORT." )
+    <*> strOption
+      (  long "token"
+      <> metavar "TOKEN"
+      <> lookupFromEnv "VAULT_TOKEN"
+      <> help "Token to authenticate to Vault with. Also configurable via VAULT_TOKEN.")
+    <*> strOption
+      (  long "secrets-file"
+      <> metavar "FILENAME"
+      <> lookupFromEnv "VAULTENV_SECRETS_FILE"
+      <> help ("Config file specifying which secrets to request. Also configurable " ++
+               "via VAULTENV_SECRETS_FILE." ))
+    <*> argument str
+      (  metavar "CMD"
+      <> help "command to run after fetching secrets")
+    <*> many (argument str
+      (  metavar "ARGS..."
+      <> help "Arguments to pass to CMD, defaults to nothing"))
+    <*>
+      ( flag (efNoConnectTls envFlags) True
+        (  long "no-connect-tls"
+        <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
+                "configurable via VAULTENV_NO_CONNECT_TLS."))
+      <|> flag (efNoConnectTls envFlags) False
+        (  long "connect-tls"
+        <> help ("Always connect to Vault via TLS. Default: use TLS. Can be used " ++
+                 "to override VAULTENV_NO_CONNECT_TLS.")
+        )
+      )
+    <*>
+      ( flag (efNoValidateCerts envFlags) True
+        (  long "no-validate-certs"
+        <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
+                "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS."))
+      <|> flag (efNoValidateCerts envFlags) False
+        (  long "validate-certs"
+        <> help ("Always validate TLS certificates when connecting to Vault. Default: " ++
+                 "validate certs. Can be used to override VAULTENV_NO_CONNECT_TLS.")
+        )
+      )
+    <*>
+      ( flag (efNoInheritEnv envFlags) True
+        (  long "no-inherit-env"
+        <> help ("Don't merge the parent environment with the secrets file. Default: " ++
+                "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV."))
+      <|> flag (efNoInheritEnv envFlags) False
+        (  long "inherit-env"
+        <> help ("Always merge the parent environment with the secrets file. Default: " ++
+                 "merge environments. Can be used to override VAULTENV_NO_INHERIT_ENV.")
+        )
+      )
+    <*> (MilliSeconds <$> option auto
+            (  long "retry-base-delay-milliseconds"
+            <> metavar "MILLISECONDS"
+            <> lookupFromEnvWithDefault "VAULTENV_RETRY_BASE_DELAY_MS" 40
+            <> help ("Base delay for vault connection retrying. Defaults to 40ms. " ++
+                     "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS.")))
+    <*> option auto
+      (  long "retry-attempts"
+      <> metavar "NUM"
+      <> lookupFromEnvWithDefault "VAULTENV_RETRY_ATTEMPTS" 9
+      <> help "Maximum number of vault connection retries. Defaults to 9")
+  where
+    lookupFromEnv key = foldMap value (lookup key envVars)
+    lookupFromEnvWithDefault key defVal = maybe (value defVal) value (readFromEnvironment key)
+
+    readFromEnvironment :: Read a => String -> Maybe a
+    readFromEnvironment var = lookup var envVars >>= Read.readMaybe

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -80,7 +80,7 @@ parseEnvFlags envVars
 optionsParserWithInfo :: EnvFlags -> [EnvVar] -> OptParse.ParserInfo Options
 optionsParserWithInfo envFlags localEnvVars =
   OptParse.info
-    (optionsParser envFlags localEnvVars <**> OptParse.helper)
+    (OptParse.helper <*> optionsParser envFlags localEnvVars)
     (OptParse.fullDesc <> OptParse.header "vaultenv - run programs with secrets from HashiCorp Vault")
 
 -- | Parser for our CLI options. Seems intimidating, but is straightforward

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -112,59 +112,67 @@ optionsParserWithInfo envFlags localEnvVars =
 -- type @String@.
 optionsParser :: EnvFlags -> [EnvVar] -> OptParse.Parser Options
 optionsParser envFlags envVars = Options
-    <$> strOption
-      (  long "host"
+    <$> host
+    <*> port
+    <*> token
+    <*> secretsFile
+    <*> cmd
+    <*> cmdArgs
+    <*> noConnectTls
+    <*> noValidateCerts
+    <*> noInheritEnv
+    <*> baseDelayMs
+    <*> retryAttempts
+  where
+    host = strOption
+      $  long "host"
       <> metavar "HOST"
       <> value "localhost"
       <> readValueFromEnv "VAULT_HOST" envVars
       <> help ("Vault host, either an IP address or DNS name. Defaults to localhost. " ++
-               "Also configurable via VAULT_HOST."))
-    <*> option auto
-      (  long "port"
+               "Also configurable via VAULT_HOST.")
+    port = option auto
+      $  long "port"
       <> metavar "PORT"
       <> readValueFromEnvWithDefault "VAULT_PORT" 8200 envVars
-      <> help "Vault port. Defaults to 8200. Also configurable via VAULT_PORT." )
-    <*> strOption
-      (  long "token"
+      <> help "Vault port. Defaults to 8200. Also configurable via VAULT_PORT."
+    token = strOption
+      $  long "token"
       <> metavar "TOKEN"
       <> readValueFromEnv "VAULT_TOKEN" envVars
-      <> help "Token to authenticate to Vault with. Also configurable via VAULT_TOKEN.")
-    <*> strOption
-      (  long "secrets-file"
+      <> help "Token to authenticate to Vault with. Also configurable via VAULT_TOKEN."
+    secretsFile = strOption
+      $  long "secrets-file"
       <> metavar "FILENAME"
       <> readValueFromEnv "VAULTENV_SECRETS_FILE" envVars
       <> help ("Config file specifying which secrets to request. Also configurable " ++
-               "via VAULTENV_SECRETS_FILE." ))
-    <*> argument str
-      (  metavar "CMD"
-      <> help "command to run after fetching secrets")
-    <*> many (argument str
+               "via VAULTENV_SECRETS_FILE." )
+    cmd = argument str
+      $  metavar "CMD"
+      <> help "command to run after fetching secrets"
+    cmdArgs =  many $ argument str
       (  metavar "ARGS..."
-      <> help "Arguments to pass to CMD, defaults to nothing"))
-    <*>
-      ( flag (efNoConnectTls envFlags) True
+      <> help "Arguments to pass to CMD, defaults to nothing")
+    noConnectTls =
+       flag (efNoConnectTls envFlags) True
         (  long "no-connect-tls"
         <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
                 "configurable via VAULTENV_NO_CONNECT_TLS."))
       <|> flag (efNoConnectTls envFlags) False
         (  long "connect-tls"
         <> help ("Always connect to Vault via TLS. Default: use TLS. Can be used " ++
-                 "to override VAULTENV_NO_CONNECT_TLS.")
-        )
-      )
-    <*>
-      ( flag (efNoValidateCerts envFlags) True
+                 "to override VAULTENV_NO_CONNECT_TLS."))
+    noValidateCerts =
+      flag (efNoValidateCerts envFlags) True
         (  long "no-validate-certs"
         <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
                 "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS."))
       <|> flag (efNoValidateCerts envFlags) False
         (  long "validate-certs"
         <> help ("Always validate TLS certificates when connecting to Vault. Default: " ++
-                 "validate certs. Can be used to override VAULTENV_NO_CONNECT_TLS.")
-        )
-      )
-    <*>
-      ( flag (efNoInheritEnv envFlags) True
+                 "validate certs. Can be used to override VAULTENV_NO_CONNECT_TLS."))
+    noInheritEnv =
+      flag (efNoInheritEnv envFlags) True
         (  long "no-inherit-env"
         <> help ("Don't merge the parent environment with the secrets file. Default: " ++
                 "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV."))
@@ -173,18 +181,17 @@ optionsParser envFlags envVars = Options
         <> help ("Always merge the parent environment with the secrets file. Default: " ++
                  "merge environments. Can be used to override VAULTENV_NO_INHERIT_ENV.")
         )
-      )
-    <*> (MilliSeconds <$> option auto
-            (  long "retry-base-delay-milliseconds"
-            <> metavar "MILLISECONDS"
-            <> readValueFromEnvWithDefault "VAULTENV_RETRY_BASE_DELAY_MS" 40 envVars
-            <> help ("Base delay for vault connection retrying. Defaults to 40ms. " ++
-                     "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS.")))
-    <*> option auto
-      (  long "retry-attempts"
+    baseDelayMs = MilliSeconds <$> (option auto
+      $  long "retry-base-delay-milliseconds"
+      <> metavar "MILLISECONDS"
+      <> readValueFromEnvWithDefault "VAULTENV_RETRY_BASE_DELAY_MS" 40 envVars
+      <> help ("Base delay for vault connection retrying. Defaults to 40ms. " ++
+                "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS."))
+    retryAttempts = option auto
+      $  long "retry-attempts"
       <> metavar "NUM"
       <> readValueFromEnvWithDefault "VAULTENV_RETRY_ATTEMPTS" 9 envVars
-      <> help "Maximum number of vault connection retries. Defaults to 9")
+      <> help "Maximum number of vault connection retries. Defaults to 9"
 
 -- ! Attempt to parse an optparse default value modifier from a list of
 -- environment variables. This function returns an empty option modifier in

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -112,11 +112,29 @@ optionsParserWithInfo envFlags localEnvVars =
 -- type @String@.
 --
 -- Another thing that should be noted is the way we use the Alternate instance
--- of Parsers in order to provide dual options. The @noConnectTls@,
--- @noValidateCerts@ and @noInheritEnv@ parsers constist of two parts. One for
--- the affirmative and one for the negative case. This is required so
--- we can override environment variables, since optparse-applicative does not
--- provide an abstraction for this by itself.
+-- of @Parser@s. The @connectTls@, @validateCerts@ and @inheritEnv@ parsers all
+-- have a cousin prefixed with @no@. Combining these with the alternate
+-- instance like so
+--
+-- @
+--    noConnectTls <|> connectTls
+-- @
+--
+-- means that they are both mutually exclusive.
+--
+-- Why do we have the options for the affirmative case? (e.g. why does
+-- @--connect-tls@ exist if we default to that behavior?) Because we want to be
+-- able to override all config that happens via environment variables on the
+-- CLI. So @VAULTENV_NO_CONNECT_TLS=true vaultenv --connect-tls@ should connect
+-- to Vault over a secure connection. Without this option, this use case is not
+-- possible.
+--
+-- The way we do this in the parser is by taking an @EnvFlags@ record which
+-- contains the settings that were provided via environment variables (and the
+-- defaults, if there wasn't anything configured). We use this record to set
+-- the default values of the different behaviour switches. So, if an
+-- environment variable is used to configure the TLS option, that value will
+-- always be used, except if it is overridden on the CLI.
 optionsParser :: EnvFlags -> [EnvVar] -> OptParse.Parser Options
 optionsParser envFlags envVars = Options
     <$> host

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -125,76 +125,86 @@ optionsParser envFlags envVars = Options
     <*> secretsFile
     <*> cmd
     <*> cmdArgs
-    <*> noConnectTls
-    <*> noValidateCerts
-    <*> noInheritEnv
+    <*> (noConnectTls    <|> connectTls)
+    <*> (noValidateCerts <|> validateCerts)
+    <*> (noInheritEnv    <|> inheritEnv)
     <*> baseDelayMs
     <*> retryAttempts
   where
-    host = strOption
+    host
+      =  strOption
       $  long "host"
       <> metavar "HOST"
       <> value "localhost"
       <> readValueFromEnv "VAULT_HOST" envVars
       <> help ("Vault host, either an IP address or DNS name. Defaults to localhost. " ++
                "Also configurable via VAULT_HOST.")
-    port = option auto
+    port
+      =  option auto
       $  long "port"
       <> metavar "PORT"
       <> readValueFromEnvWithDefault "VAULT_PORT" 8200 envVars
       <> help "Vault port. Defaults to 8200. Also configurable via VAULT_PORT."
-    token = strOption
+    token
+      =  strOption
       $  long "token"
       <> metavar "TOKEN"
       <> readValueFromEnv "VAULT_TOKEN" envVars
       <> help "Token to authenticate to Vault with. Also configurable via VAULT_TOKEN."
-    secretsFile = strOption
+    secretsFile
+      =  strOption
       $  long "secrets-file"
       <> metavar "FILENAME"
       <> readValueFromEnv "VAULTENV_SECRETS_FILE" envVars
       <> help ("Config file specifying which secrets to request. Also configurable " ++
                "via VAULTENV_SECRETS_FILE." )
-    cmd = argument str
+    cmd
+      =  argument str
       $  metavar "CMD"
       <> help "command to run after fetching secrets"
-    cmdArgs =  many $ argument str
+    cmdArgs
+      =  many $ argument str
       (  metavar "ARGS..."
       <> help "Arguments to pass to CMD, defaults to nothing")
-    noConnectTls =
-       flag (efNoConnectTls envFlags) True
-        (  long "no-connect-tls"
-        <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
-                "configurable via VAULTENV_NO_CONNECT_TLS."))
-      <|> flag (efNoConnectTls envFlags) False
-        (  long "connect-tls"
-        <> help ("Always connect to Vault via TLS. Default: use TLS. Can be used " ++
-                 "to override VAULTENV_NO_CONNECT_TLS."))
-    noValidateCerts =
-      flag (efNoValidateCerts envFlags) True
-        (  long "no-validate-certs"
-        <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
-                "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS."))
-      <|> flag (efNoValidateCerts envFlags) False
-        (  long "validate-certs"
-        <> help ("Always validate TLS certificates when connecting to Vault. Default: " ++
-                 "validate certs. Can be used to override VAULTENV_NO_CONNECT_TLS."))
-    noInheritEnv =
-      flag (efNoInheritEnv envFlags) True
-        (  long "no-inherit-env"
-        <> help ("Don't merge the parent environment with the secrets file. Default: " ++
-                "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV."))
-      <|> flag (efNoInheritEnv envFlags) False
-        (  long "inherit-env"
-        <> help ("Always merge the parent environment with the secrets file. Default: " ++
-                 "merge environments. Can be used to override VAULTENV_NO_INHERIT_ENV.")
-        )
-    baseDelayMs = MilliSeconds <$> (option auto
+    noConnectTls
+      =  flag (efNoConnectTls envFlags) True
+      $  long "no-connect-tls"
+      <> help ("Don't use TLS when connecting to Vault. Default: use TLS. Also " ++
+              "configurable via VAULTENV_NO_CONNECT_TLS.")
+    connectTls
+      =  flag (efNoConnectTls envFlags) False
+      $  long "connect-tls"
+      <> help ("Always connect to Vault via TLS. Default: use TLS. Can be used " ++
+                "to override VAULTENV_NO_CONNECT_TLS.")
+    noValidateCerts
+      =  flag (efNoValidateCerts envFlags) True
+      $  long "no-validate-certs"
+      <> help ("Don't validate TLS certificates when connecting to Vault. Default: " ++
+              "validate certs. Also configurable via VAULTENV_NO_VALIDATE_CERTS.")
+    validateCerts
+      =  flag (efNoValidateCerts envFlags) False
+      $  long "validate-certs"
+      <> help ("Always validate TLS certificates when connecting to Vault. Default: " ++
+                "validate certs. Can be used to override VAULTENV_NO_CONNECT_TLS.")
+    noInheritEnv
+      =  flag (efNoInheritEnv envFlags) True
+      $  long "no-inherit-env"
+      <> help ("Don't merge the parent environment with the secrets file. Default: " ++
+              "merge environments. Also configurable via VAULTENV_NO_INHERIT_ENV.")
+    inheritEnv
+      =  flag (efNoInheritEnv envFlags) False
+      $  long "inherit-env"
+      <> help ("Always merge the parent environment with the secrets file. Default: " ++
+                "merge environments. Can be used to override VAULTENV_NO_INHERIT_ENV.")
+    baseDelayMs
+      =  MilliSeconds <$> (option auto
       $  long "retry-base-delay-milliseconds"
       <> metavar "MILLISECONDS"
       <> readValueFromEnvWithDefault "VAULTENV_RETRY_BASE_DELAY_MS" 40 envVars
       <> help ("Base delay for vault connection retrying. Defaults to 40ms. " ++
                 "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS."))
-    retryAttempts = option auto
+    retryAttempts
+      =  option auto
       $  long "retry-attempts"
       <> metavar "NUM"
       <> readValueFromEnvWithDefault "VAULTENV_RETRY_ATTEMPTS" 9 envVars


### PR DESCRIPTION
This PR allows us to configure `vaultenv` using environment variables (fixes #28). We support setting the following options:

 - `--host`
 - `--port`
 - `--token`
 - `--secrets-file`
 - `--[no-]connect-tls`
 - `--[no-]validate-certs`
 - `--[no-]inherit-env`
 - `--retry-base-delay-milliseconds`
 - `--retry-attempts`

Notes:

 - The first three are named after the corresponding variables which can be used to configure the official `vault` CLI: `VAULT_HOST`, `VAULT_PORT`, and `VAULT_TOKEN`. 
 - The others are prefixed with `VAULTENV`. 
 - The options which disable defaults are named `VAULTENV_NO_*`, because they explicitly disable the default behavior.
 - CLI arguments take precedence over environment variables.
 - Boolean settings are parsed from the strings `"true"` and `"false"`. No other formats are supported.
 - Because some users might want to override `VAULTENV_NO_*` environment variables, I added in new options: `--validate-certs`, `--inherit-env`, `--connect-tls`, which are no-ops by default, but can override these environment variables. These options are mutually exclusive: vaultenv will throw an error when it encounters both `--connect-tls` and `--no-connect-tls`. (Although the error message isn't that great)