### PR TITLE
Use single threaded GHC RTS

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,5 @@ executables:
   vaultenv:
     main: Main.hs
     source-dirs: app
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N
     dependencies:
       - vaultenv


### PR DESCRIPTION
`vaultenv` does not use threads, and asynchronous IO is also provided by the
single threaded RTS. Secrets can therefore still be fetched in parallel.
In a quick test, this also appears to be faster than using the threaded RTS.