### PR TITLE
config: Search for config files in default places

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ CLI flags and environment variable lookups). Vaultenv currently looks for these
 files in the following places:
 
  - `/etc/vaultenv.conf`
- - `$HOME/.vaultenv/config.conf`
+ - `$HOME/.config/vaultenv/vaultenv.conf`
  - `$CWD/.env`
 
 These config files support the exact same syntax as the environment variables

--- a/README.md
+++ b/README.md
@@ -144,7 +144,18 @@ Available options:
 
 ```
 
-## Secret specification
+## Configuration
+
+Vaultenv reads configuration from two types of files:
+
+ - A specification of secrets to fetch.
+ - Configuration options for `vaultenv` itself, mostly connection related.
+
+Decoupling these is useful, because this allows for e.g. changing which secrets
+are fetched on a per project basis, while the connection options stay the same.
+Let's first discuss secrets files.
+
+### Secret specification
 
 There are two versions of this specification format. The first version shipped
 with the initial version of Vaultenv, but doesn't allow users to specify custom
@@ -195,7 +206,41 @@ Vaultenv will make the following environment variables available:
  - `FOOBAR` with the contents of the `foobar` field of the secret at
    `production/third-party`.
 
-## Allowed characters
+### Behavior configuration
+
+Vaultenv supports loading behavior configuration from files (in addition to the
+CLI flags and environment variable lookups). Vaultenv currently looks for these
+files in the following places:
+
+ - `/etc/vaultenv.conf`
+ - `$HOME/.vaultenv/config.conf`
+ - `$CWD/.env`
+
+These config files support the exact same syntax as the environment variables
+that you can use to configure Vaultenv. See the `--help` output for a list of
+what's available.
+
+These files follow the `.env` format (as popularized by [this Ruby
+gem](https://github.com/bkeepers/dotenv)). An example:
+
+```
+# /etc/vaultenv.conf
+# Also: comments are allowed if they start with `#`.
+VAULT_TOKEN="your-vault-token"
+VAULT_PORT="8200"
+VAULTENV_INHERIT_ENV="yes"
+```
+
+This is mostly useful for use on development machines. It allows you to:
+
+ - Set global connection options on a per-machine basis. Useful if you run a
+   Vault instance in your VPN.
+ - Set per-user tokens.
+ - Set per-project secrets files.
+
+All while running Vaultenv without any CLI args.
+
+## Allowed characters in environment variables
 
 We disallow the following in any path to keep the parser and format simple and
 unambiguous:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -89,7 +89,7 @@ main = do
   envFileSettings <- readConfigFromEnvFiles
 
   -- Deduplicate, give precedence to set env vars over .env files
-  let envAndEnvFileConfig = nubBy (\(x, _) (y, _) -> x == y) localEnvVars ++ envFileSettings
+  let envAndEnvFileConfig = nubBy (\(x, _) (y, _) -> x == y) (localEnvVars ++ envFileSettings)
 
   cliAndEnvAndEnvFileOptions <- parseOptionsFromEnvAndCli envAndEnvFileConfig
 

--- a/package.yaml
+++ b/package.yaml
@@ -10,6 +10,8 @@ dependencies:
   - bytestring
   - connection
   - containers
+  - dotenv
+  - directory
   - http-conduit
   - http-client
   - lens

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -358,19 +358,20 @@ readConfigFromEnvFiles = do
 
   -- @doesFileExist@ doesn't throw exceptions, it catches @IOError@s and
   -- returns @False@ if those are encountered.
-  loadMachineConfig <- Dir.doesFileExist machineConfigFile
-  loadUserConfig <- case userConfigFile of
-     Nothing -> pure False
-     Just fp -> Dir.doesFileExist fp
-  loadCwdConfig <- Dir.doesFileExist cwdConfigFile
-
-  machineConfig <- if loadMachineConfig
+  machineConfigExists <- Dir.doesFileExist machineConfigFile
+  machineConfig <- if machineConfigExists
     then DotEnv.parseFile machineConfigFile
     else pure []
-  userConfig <- if loadUserConfig
+
+  userConfigExists <- case userConfigFile of
+     Nothing -> pure False
+     Just fp -> Dir.doesFileExist fp
+  userConfig <- if userConfigExists
     then DotEnv.parseFile (fromJust userConfigFile) -- safe because of loadUserConfig
     else pure []
-  cwdConfig <- if loadCwdConfig
+
+  cwdConfigExists <- Dir.doesFileExist cwdConfigFile
+  cwdConfig <- if cwdConfigExists
     then DotEnv.parseFile cwdConfigFile
     else pure []
 


### PR DESCRIPTION
Fixes https://github.com/channable/vaultenv/issues/57

This is an enhancement to make `vaultenv` more useful on devmachines.

Currently users need to specify stuff like `--host`, `--port`, and `--token` manually (or create a wrapper script which does). This changes `vaultenv` to look for for files with the `.env` format in three places:

 - `/etc/vaultenv.conf`
 - `$HOME/.config/vaultenv/vaultenv.conf`
 - `$(cwd)/.env`

New config file precedence in case of duplicate settings:

 - `/etc/vaultenv.conf`
 - `$HOME/.config/vaultenv/vaultenv.conf`
 - `$(cwd)/.env`
 - Env vars which are set
 - CLI options

Later items in the list take precedence