### PR TITLE
app: Add explicit --version command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,10 @@
 # How to release `vaultenv`
 
  1. Increment the `version` field in `package.yaml`
- 2. Increment the `version` in `src/Config.hs` in `optionsParserWithInfo`
- 3. Create a git commit
- 4. Tag: `git tag -a v<VERSION>`. Write a changelog.
- 5. Compile and package. Take care to use libc from at least Xenial.
- 6. `git push origin master --tags`
- 7. Go to https://github.com/channable/vaultenv/releases
- 8. Click "Draft a new release"
- 9. Paste the changelog and attach the binaries
+ 2. Create a git commit
+ 3. Tag: `git tag -a v<VERSION>`. Write a changelog.
+ 4. Compile and package. Take care to use libc from at least Xenial.
+ 5. `git push origin master --tags`
+ 6. Go to https://github.com/channable/vaultenv/releases
+ 7. Click "Draft a new release"
+ 8. Paste the changelog and attach the binaries

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -20,9 +20,10 @@ import Control.Applicative ((<*>), (<|>))
 import Data.List (intercalate, nubBy)
 import Data.Maybe (fromJust)
 import Data.Monoid ((<>))
-
+import Data.Version (showVersion)
 import Options.Applicative (value, long, auto, option, metavar, help, flag,
                             str, argument, many, strOption)
+import Paths_vaultenv (version) -- Magic to get the version field from cabal.
 import System.IO.Error (catchIOError)
 
 import qualified Configuration.Dotenv as DotEnv
@@ -133,8 +134,12 @@ parseEnvFlags envVars
 optionsParserWithInfo :: EnvFlags -> [EnvVar] -> OptParse.ParserInfo Options
 optionsParserWithInfo envFlags localEnvVars =
   OptParse.info
-    (OptParse.helper <*> optionsParser envFlags localEnvVars)
-    (OptParse.fullDesc <> OptParse.header "vaultenv 0.8.1 - run programs with secrets from HashiCorp Vault")
+    (OptParse.helper <*> versionOption <*> optionsParser envFlags localEnvVars)
+    (OptParse.fullDesc <> OptParse.header header)
+  where
+    versionOption = OptParse.infoOption (showVersion version) (long "version" <> help "Show version")
+    header = "vaultenv " ++ showVersion version ++ " - run programs with secrets from HashiCorp Vault"
+
 
 -- | Parser for our CLI options. Seems intimidating, but is straightforward
 -- once you know about applicative parsing patterns. We construct a parser for


### PR DESCRIPTION
This is the actual proper fix for https://github.com/channable/vaultenv/issues/52

I found out how to get short-circuiting behavior (I was afraid
this would require changes to the Config datatype), but apparently
optparse-applicative has something for this.

I also found out how you can get information on the program version
from the Cabal file, which means less duplication of this
information.

cc @mesaugat 