### PR TITLE
vaultenv no longer supports double underscore in env var names

### DIFF
--- a/src/SecretsFile.hs
+++ b/src/SecretsFile.hs
@@ -197,7 +197,7 @@ secretP version mount = do
 -- Please open a ticket if you require looser restrictions.
 secretVarP :: Parser String
 secretVarP = do
-  var <- intercalate "_" <$> sepBy1 (some MPC.alphaNumChar) (MPC.string "_")
+  var <- intercalate "_" <$> sepBy1 (some MPC.alphaNumChar) (some (MPC.string "_"))
   _ <- symbol "="
   pure var
 

--- a/test/golden/v1.secrets
+++ b/test/golden/v1.secrets
@@ -2,3 +2,5 @@ foo#bar
 foo/bar#baz
 FOO=bar#baz
 BAR=foo/baz#quix
+single_underscore=foo/single#underscore
+double__underscore=foo/double#underscore


### PR DESCRIPTION
This is regression we hit with the latest version of vaultenv. This was previously supported and is required by some node.js packages.

Added new double underscore test cases...

```
    SecretFile
      SecretFile.readSecretList
        parses all golden tests succesfully FAILED [1]
        rejects all invalid examples succesfully

    Failures:

      test/SecretFileSpec.hs:17:7:
      1) SecretFile.SecretFile.readSecretList parses all golden tests succesfully
           predicate failed on: [Right [Secret {sMount = "secret", sPath = "foo/bar", sKey = "baz", sVarName = "BAR_BAZ"}],Right [Secret {sMount = "secret", sPath = "foob@ar", sKey = "baz", sVarName = "FOOB@AR_BAZ"},Secret {sMount = "secret", sPath = "fo\1364ob@ar", sKey = "baz", sVarName = "FO\1364OB@AR_BAZ"}],Right [Secret {sMount = "secret", sPath = "stuff/and", sKey = "things", sVarName = "SECRET_STUFF_AND_THINGS"}],Left test/golden/v1.secrets:6:19:
           unexpected '='
           expecting '#' or path component
           ,Right [Secret {sMount = "secret", sPath = "foo", sKey = "bar", sVarName = "SECRET_FOO_BAR"},Secret {sMount = "secret", sPath = "foo/baz", sKey = "bar", sVarName = "BAR"},Secret {sMount = "otherthing", sPath = "foo", sKey = "bar", sVarName = "OTHERTHING_FOO_BAR"},Secret {sMount = "otherthing", sPath = "foo/baz", sKey = "bar", sVarName = "BAR"}],Right [Secret {sMount = "secret", sPath = "VERSIONfoobar", sKey = "foo", sVarName = "VERSIONFOOBAR_FOO"}]]

      To rerun use: --match "/SecretFile/SecretFile.readSecretList/parses all golden tests succesfully/"
```

Fixed double underscore in env var name...

```
    Progress 1/2: vaultenv-0.9.0
    SecretFile
      SecretFile.readSecretList
        parses all golden tests succesfully
        rejects all invalid examples succesfully

    Finished in 0.0075 seconds
    2 examples, 0 failures
```