### PR TITLE
Fix characters allowed in environment variables

### DIFF
--- a/src/SecretsFile.hs
+++ b/src/SecretsFile.hs
@@ -197,7 +197,7 @@ secretP version mount = do
 -- Please open a ticket if you require looser restrictions.
 secretVarP :: Parser String
 secretVarP = do
-  var <- intercalate "_" <$> sepBy1 (some MPC.alphaNumChar) (MPC.string "_")
+  var <- intercalate "_" <$> sepBy1 (some MPC.alphaNumChar) (some (MPC.string "_"))
   _ <- symbol "="
   pure var
 

--- a/test/golden/v1.secrets
+++ b/test/golden/v1.secrets
@@ -2,3 +2,5 @@ foo#bar
 foo/bar#baz
 FOO=bar#baz
 BAR=foo/baz#quix
+single_underscore=foo/single#underscore
+double__underscore=foo/double#underscore

--- a/test/golden/v1.secrets
+++ b/test/golden/v1.secrets
@@ -4,3 +4,4 @@ FOO=bar#baz
 BAR=foo/baz#quix
 single_underscore=foo/single#underscore
 double__underscore=foo/double#underscore
+_leading_underscore=foo/double#underscore

--- a/test/integration/happy_path.sh
+++ b/test/integration/happy_path.sh
@@ -2,7 +2,7 @@
 
 set -eufo pipefail
 
-echo "1..4"
+echo "1..6"
 
 if [ $VAULT_TOKEN = "integration" ]; then
   echo "ok 1 - vault token set"
@@ -34,5 +34,6 @@ test_env_contents() {
 test_env_contents 2 "TESTING_KEY" "testing42" ${VAULT_SEEDS}
 test_env_contents 3 "TEST_TEST" "testing42" ${VAULT_SEEDS}
 test_env_contents 4 "TEST__TEST" "testing42" ${VAULT_SEEDS}
+test_env_contents 5 "_TEST__TEST" "testing42" ${VAULT_SEEDS}
 
-test_env_contents 5 "SECRET_TESTING_KEY" "testing42" ${VAULT_SEEDS_V2}
+test_env_contents 6 "SECRET_TESTING_KEY" "testing42" ${VAULT_SEEDS_V2}

--- a/test/integration/happy_path.sh
+++ b/test/integration/happy_path.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -e
+set -eufo pipefail
 
-echo "1..3"
+echo "1..4"
 
 if [ $VAULT_TOKEN = "integration" ]; then
   echo "ok 1 - vault token set"
@@ -10,16 +10,28 @@ else
   echo "not ok 1 - vault token not set"
 fi
 
-stack exec -- vaultenv \
-  --no-connect-tls \
-  --host ${VAULT_HOST} \
-  --port ${VAULT_PORT} \
-  --secrets-file ${VAULT_SEEDS} -- \
-  /bin/echo "ok 2 - happy path"
+test_env_contents() {
+  # Arguments:
+  #
+  #  $1 - Test number
+  #  $2 - Env var to check
+  #  $3 - Contents of (first line of) env var
+  #  $4 - Secrets file path
 
-stack exec -- vaultenv \
-  --no-connect-tls \
-  --host ${VAULT_HOST} \
-  --port ${VAULT_PORT} \
-  --secrets-file ${VAULT_SEEDS_V2} -- \
-  /bin/echo "ok 3 - happy path v2"
+  OUTPUT=$(stack exec -- vaultenv \
+    --no-connect-tls \
+    --host ${VAULT_HOST} \
+    --port ${VAULT_PORT} \
+    --secrets-file $4 -- \
+    /usr/bin/env)
+
+  GREPPED=`grep "^$2" <<< $OUTPUT`
+  grep $3 <<< $GREPPED
+
+  echo "ok $1 - happy path"
+}
+
+test_env_contents 2 "TESTING_KEY" "testing42" ${VAULT_SEEDS}
+test_env_contents 3 "TEST_TEST" "testing42" ${VAULT_SEEDS}
+
+test_env_contents 4 "SECRET_TESTING_KEY" "testing42" ${VAULT_SEEDS_V2}

--- a/test/integration/happy_path.sh
+++ b/test/integration/happy_path.sh
@@ -33,5 +33,6 @@ test_env_contents() {
 
 test_env_contents 2 "TESTING_KEY" "testing42" ${VAULT_SEEDS}
 test_env_contents 3 "TEST_TEST" "testing42" ${VAULT_SEEDS}
+test_env_contents 4 "TEST__TEST" "testing42" ${VAULT_SEEDS}
 
-test_env_contents 4 "SECRET_TESTING_KEY" "testing42" ${VAULT_SEEDS_V2}
+test_env_contents 5 "SECRET_TESTING_KEY" "testing42" ${VAULT_SEEDS_V2}

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -29,6 +29,7 @@ testing2#foo
 testing2#bar
 TEST_TEST=testing#key
 TEST__TEST=testing#key
+_TEST__TEST=testing#key
 EOF
 
 export VAULT_SEEDS_V2="$(mktemp)"

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -8,7 +8,7 @@ export VAULT_ADDR="http://${VAULT_HOST}:${VAULT_PORT}"
 set -e
 
 # Check the vault command exists:
-if ! which vault; then 
+if ! which vault; then
   echo "vault: command not found"
   exit 1
 fi
@@ -27,6 +27,7 @@ testing#key
 testing#otherkey
 testing2#foo
 testing2#bar
+TEST_TEST=testing#key
 EOF
 
 export VAULT_SEEDS_V2="$(mktemp)"

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -28,6 +28,7 @@ testing#otherkey
 testing2#foo
 testing2#bar
 TEST_TEST=testing#key
+TEST__TEST=testing#key
 EOF
 
 export VAULT_SEEDS_V2="$(mktemp)"

--- a/test/invalid/wrong_envvar_names.secrets
+++ b/test/invalid/wrong_envvar_names.secrets
@@ -1,0 +1,1 @@
+5_shouldnt_lead_with_numbers=testing#secret


### PR DESCRIPTION
This PR supersedes https://github.com/channable/vaultenv/pull/60 and fixes issues with the `vaultenv` parser being too strict about environment variable names