### PR TITLE
Add integration with travis-ci and publish binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ after_success:
       stack exec -- cp $(which vaultenv) .
       # Use a user within the organization and generate a github token
       ./github-release release --token=$GITHUB_TOKEN --owner=$GITHUB_USER --repo=vaultenv --title=v$TRAVIS_TAG  --tag=$TRAVIS_TAG
-      ./github-release upload  --token=$GITHUB_TOKEN --owner=$GITHUB_USER --repo=vaultenv --file=vaultenv --tag=$TRAVIS_TAG --name=vautenv-$TRAVIS_TAG-$TRAVIS_OS_NAME-x86_64
+      ./github-release upload  --token=$GITHUB_TOKEN --owner=$GITHUB_USER --repo=vaultenv --file=vaultenv --tag=$TRAVIS_TAG --name=vaultenv-$TRAVIS_TAG-$TRAVIS_OS_NAME-x86_64
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+sudo: true
+language: generic
+
+os:
+  - linux
+  - osx
+
+cache:
+  directories:
+  - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
+
+env:
+  global:
+    - GITHUB_RELEASE_VERSION=1.2.4
+
+before_install:
+  - mkdir -p ~/.local/bin
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        travis_retry curl -sSL https://www.stackage.org/stack/osx-x86_64   | tar xz --strip-components=1 --include  '*/stack' -C ~/.local/bin
+    else
+        travis_retry curl -sSL https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    fi
+
+install:
+  - stack setup --no-terminal
+  - stack build --only-dependencies --test --copy-bins
+
+script:
+  - stack test --copy-bins
+
+after_success:
+  - |
+    if [ -n "$TRAVIS_TAG" ]; then
+      travis_retry curl -L https://github.com/tfausak/github-release/releases/download/$GITHUB_RELEASE_VERSION/github-release-$TRAVIS_OS_NAME.gz | gunzip > github-release
+      chmod a+x github-release
+      stack exec -- cp $(which vaultenv) .
+      # Use a user within the organization and generate a github token
+      ./github-release release --token=$GITHUB_TOKEN --owner=$GITHUB_USER --repo=vaultenv --title=v$TRAVIS_TAG  --tag=$TRAVIS_TAG
+      ./github-release upload  --token=$GITHUB_TOKEN --owner=$GITHUB_USER --repo=vaultenv --file=vaultenv --tag=$TRAVIS_TAG --name=vautenv-$TRAVIS_TAG-$TRAVIS_OS_NAME-x86_64
+    fi;


### PR DESCRIPTION
Closes issues #67 # #61

This PR adds the integrations with travis-ci and executes the suite test for all branches when travis-ci detects that a new tag has been pushed runs` stack build `,  `stack test` and create a new release and uploads the binaries built for osx and Linux.
The format will be `vaultenv-v$version-$os`  (vaultenv-v0.9.1-osx) I tested forking the repo and trying by myself

<img width="1046" alt="Screen Shot 2019-04-23 at 14 38 34" src="https://user-images.githubusercontent.com/4852949/56619061-f3962700-65e9-11e9-9b06-e69d747b2bf6.png">


To create the release, you will need to define two environment variables in travis-ci:
- A user that have permissions over the repo `$GITHUB_USER = lpaulmp`
- Generate a Github token with permissions over the repo `$GITHUB_TOKEN = mytoken1234`.


@duijf I hope you find this useful 