### PR TITLE
Turn off Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: true
 language: generic
 
+notifications:
+  email: false
+
 os:
   - linux
   - osx


### PR DESCRIPTION
I don't want spam for builds, especially not builds that pass. If anybody likes the failed build notifications we could change it to [`on_success: never`](https://docs.travis-ci.com/user/notifications/#configuring-email-notifications) to still get mails for failed builds.