### PR TITLE
Allow overriding environment files to load

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -184,7 +184,8 @@ vaultRetryPolicy opts = Retry.fullJitterBackoff (unMilliSeconds (oRetryBaseDelay
 main :: IO ()
 main = do
   localEnvVars <- getEnvironment
-  envFileSettings <- readConfigFromEnvFiles
+
+  envFileSettings <- readConfigFromEnvFiles Nothing
 
   -- Deduplicate, give precedence to set env vars over .env files
   let envAndEnvFileConfig = nubBy (\(x, _) (y, _) -> x == y) (localEnvVars ++ envFileSettings)


### PR DESCRIPTION
This PR will add the `VAULTENV_CONFIG_FILES` / `--config-files` parameter as described in #72.

The parameter will contain a comma-separated list of filenames that are to be loaded instead of the default `/etc/vaultenv.conf,$HOME/.config/vaultenv/vaultenv.conf,$CWD/.env`.