### PR TITLE
Added addr support to vault

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -194,7 +194,7 @@ main = do
 
   let envAndEnvFileConfig = nubBy (\(x, _) (y, _) -> x == y) (localEnvVars ++ concat (reverse envFileSettings))
 
-  if True || getOptionsValue "Log level" (oLogLevel cliAndEnvAndEnvFileOptions) <= Info
+  if getOptionsValue "Log level" (oLogLevel cliAndEnvAndEnvFileOptions) <= Info
     then print cliAndEnvAndEnvFileOptions
     else pure ()
   print cliAndEnvAndEnvFileOptions
@@ -304,8 +304,8 @@ vaultEnv context = do
 
       buildEnv :: [EnvVar] -> [EnvVar]
       buildEnv secretsEnv =
-        if (getOptionsValue "CliOptions" . oInheritEnv . cCliOptions $ context)
-        then secretsEnv ++ (cLocalEnvVars context)
+        if getOptionsValue "CliOptions" . oInheritEnv . cCliOptions $ context
+        then secretsEnv ++ cLocalEnvVars context
         else secretsEnv
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,7 +22,7 @@ import Network.HTTP.Simple    (HttpException(..), Request, Response,
                                getResponseStatusCode)
 import System.Environment     (getEnvironment)
 import System.Posix.Process   (executeFile)
-import Control.Monad.Except   (ExceptT (..), MonadError, runExceptT, mapExceptT, 
+import Control.Monad.Except   (ExceptT (..), MonadError, runExceptT, mapExceptT,
                                throwError, liftEither, withExceptT)
 
 import qualified Control.Concurrent.Async   as Async
@@ -176,7 +176,7 @@ data VaultError
 -- We use a limited exponential backoff with the policy
 -- fullJitterBackoff that comes with the Retry package.
 vaultRetryPolicy :: (MonadIO m) => Options Validated Completed -> Retry.RetryPolicyM m
-vaultRetryPolicy opts = Retry.fullJitterBackoff (unMilliSeconds 
+vaultRetryPolicy opts = Retry.fullJitterBackoff (unMilliSeconds
                           (getOptionsValue oRetryBaseDelay opts) * 1000
                         )
                      <> Retry.limitRetries (
@@ -194,7 +194,7 @@ main = do
 
   cliAndEnvAndEnvFileOptions <- parseOptions localEnvVars envFileSettings
 
-  let envAndEnvFileConfig = nubBy (\(x, _) (y, _) -> x == y) 
+  let envAndEnvFileConfig = nubBy (\(x, _) (y, _) -> x == y)
                                   (localEnvVars ++ concat (reverse envFileSettings))
 
   if getOptionsValue oLogLevel cliAndEnvAndEnvFileOptions <= Info
@@ -223,7 +223,7 @@ getHttpManager opts = newManager managerSettings
                       then mkManagerSettings tlsSettings Nothing
                       else defaultManagerSettings
     tlsSettings = TLSSettingsSimple
-                { settingDisableCertificateValidation = 
+                { settingDisableCertificateValidation =
                       not $ getOptionsValue oValidateCerts opts
                 , settingDisableSession = False
                 , settingUseServerName = True
@@ -286,18 +286,18 @@ requestMountInfo :: Context -> ExceptT VaultError IO MountInfo
 requestMountInfo context =
   let
     cliOptions = cCliOptions context
-    request 
-        = setRequestManager 
+    request
+        = setRequestManager
               (cHttpManager context)
-        $ setRequestHeader "x-vault-token" 
+        $ setRequestHeader "x-vault-token"
               [SBS.pack (getOptionsValue oVaultToken cliOptions)]
-        $ setRequestPath 
+        $ setRequestPath
               (SBS.pack "/v1/sys/mounts")
-        $ setRequestPort 
+        $ setRequestPort
               (getOptionsValue oVaultPort cliOptions)
-        $ setRequestHost 
+        $ setRequestHost
               (SBS.pack (getOptionsValue oVaultHost cliOptions))
-        $ setRequestSecure 
+        $ setRequestSecure
               (getOptionsValue  oConnectTls cliOptions)
         $ defaultRequest
   in do
@@ -309,8 +309,8 @@ requestSecret :: Context -> String -> ExceptT VaultError IO VaultData
 requestSecret context secretPath =
   let
     cliOptions = cCliOptions context
-    request 
-        = setRequestManager 
+    request
+        = setRequestManager
             (cHttpManager context)
         $ setRequestHeader "x-vault-token" [SBS.pack (getOptionsValue oVaultToken cliOptions)]
         $ setRequestPath    (SBS.pack secretPath)
@@ -334,7 +334,7 @@ requestSecret context secretPath =
       Forbidden -> False
       InvalidUrl _ -> False
       SecretNotFound _ -> False
-      
+
 
       -- Errors that cannot occur at this point, but we list for
       -- exhaustiveness checking.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -35,7 +35,7 @@ import qualified Data.Foldable              as Foldable
 import qualified Data.Map                   as Map
 import qualified System.Exit                as Exit
 
-import Config (Options(..), parseOptionsFromEnvAndCli, unMilliSeconds,
+import Config (Options(..), parseOptions, unMilliSeconds,
                LogLevel(..), readConfigFromEnvFiles, getOptionsValue,
                Validated, Completed)
 import SecretsFile (Secret(..), SFError(..), readSecretList)
@@ -192,7 +192,7 @@ main = do
   localEnvVars <- getEnvironment
   envFileSettings <- readConfigFromEnvFiles
 
-  cliAndEnvAndEnvFileOptions <- parseOptionsFromEnvAndCli localEnvVars envFileSettings
+  cliAndEnvAndEnvFileOptions <- parseOptions localEnvVars envFileSettings
 
   let envAndEnvFileConfig = nubBy (\(x, _) (y, _) -> x == y) 
                                   (localEnvVars ++ concat (reverse envFileSettings))
@@ -200,7 +200,7 @@ main = do
   if getOptionsValue "Log level" (oLogLevel cliAndEnvAndEnvFileOptions) <= Info
     then print cliAndEnvAndEnvFileOptions
     else pure ()
-  print cliAndEnvAndEnvFileOptions
+
   httpManager <- getHttpManager cliAndEnvAndEnvFileOptions
 
   let context = Context { cLocalEnvVars = envAndEnvFileConfig

--- a/package.yaml
+++ b/package.yaml
@@ -52,3 +52,4 @@ tests:
     - hspec-discover
     - hspec-expectations
     - directory
+    - QuickCheck

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -141,14 +141,14 @@ instance Show Options where
     , "Token:          " ++ maybe "Unspecified" (const "*****") (oVaultToken opts)
     , "Secret file:    " ++ showSpecifiedString (oSecretFile opts)
     , "Command:        " ++ showSpecifiedString (oCmd opts)
-    , "Arguments:      " ++ (showSpecified $ oArgs opts)
-    , "Use TLS:        " ++ (showSpecified $ oConnectTls opts)
-    , "Validate certs: " ++ (showSpecified $ oValidateCerts opts)
-    , "Inherit env:    " ++ (showSpecified $ oInheritEnv opts)
-    , "Base delay:     " ++ (showSpecified $ (unMilliSeconds <$> oRetryBaseDelay opts))
-    , "Retry attempts: " ++ (showSpecified $ oRetryAttempts opts)
-    , "Log-level:      " ++ (showSpecified $ oLogLevel opts)
-    , "Use PATH:       " ++ (showSpecified $ oUsePath opts)
+    , "Arguments:      " ++ showSpecified (oArgs opts)
+    , "Use TLS:        " ++ showSpecified (oConnectTls opts)
+    , "Validate certs: " ++ showSpecified (oValidateCerts opts)
+    , "Inherit env:    " ++ showSpecified (oInheritEnv opts)
+    , "Base delay:     " ++ showSpecified (unMilliSeconds <$> oRetryBaseDelay opts)
+    , "Retry attempts: " ++ showSpecified (oRetryAttempts opts)
+    , "Log-level:      " ++ showSpecified (oLogLevel opts)
+    , "Use PATH:       " ++ showSpecified (oUsePath opts)
     ] where 
       showSpecified :: Show a => Maybe a -> String
       showSpecified (Just x) = show x
@@ -293,9 +293,7 @@ parseOptionsFromEnvAndCli localEnvVars envFileSettings =
     let results = eEnvFileSettingsOptions ++ [eLocalEnvFlagsOptions, eParseResult]
     if any isLeft results then
       die (unlines (map show $ lefts results))
-    else do
-      --print results
-      return $ foldl (flip mergeOptions) defaultOptions (rights results)
+    else return $ foldl (flip mergeOptions) defaultOptions (rights results)
 
 -- | Parses behavior flags from a list of environment variables. If an
 -- environment variable corresponding to the flag is set to @"true"@ or
@@ -521,12 +519,13 @@ optionsParser = Options
       <> help ("Always merge the parent environment with the secrets file. Default: " ++
                 "merge environments. Can be used to override VAULTENV_INHERIT_ENV.")
     baseDelayMs
-      =  fmap MilliSeconds <$> (option (Just <$> auto)
-      $  long "retry-base-delay-milliseconds"
+      =  fmap MilliSeconds <$> option (Just <$> auto)
+      (  long "retry-base-delay-milliseconds"
       <> metavar "MILLISECONDS"
       <> value Nothing
       <> help ("Base delay for vault connection retrying. Defaults to 40ms. " ++
-                "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS."))
+                "Also configurable via VAULTENV_RETRY_BASE_DELAY_MS.")
+      )
     retryAttempts
       =  option (Just <$> auto)
       $  long "retry-attempts"
@@ -608,7 +607,7 @@ readValueFromEnvWithDefault key defVal envVars
 readConfigFromEnvFiles :: IO [[(String, String)]]
 readConfigFromEnvFiles = do
   xdgDir <- (Just <$> Dir.getXdgDirectory Dir.XdgConfig "vaultenv")
-    `catchIOError` (const $ pure Nothing)
+    `catchIOError` const (pure Nothing)
   cwd <- Dir.getCurrentDirectory
   let
     machineConfigFile = "/etc/vaultenv.conf"

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -147,7 +147,7 @@ instance Show OptionsError where
     "The scheme " ++ show scheme ++ 
     " , the host " ++ show host ++ 
     " and the port " ++ show port ++  
-    " do not match the provided addr" ++ show addr
+    " do not match the provided addr " ++ show addr
 
 -- | Validates for a set of options that any provided addr is valid and that either the 
 -- scheme, host and port or that any given addr matches the other provided information.
@@ -176,7 +176,7 @@ validateCopyAddr opts
           || 
           (isJust mPort && Just addrPort /= mPort)
           || 
-          (isJust mUseTLS && addrTLS == mUseTLS)
+          (isJust mUseTLS && addrTLS /= mUseTLS)
         )
         (throwError $ HostPortSchemeAddrMismatch 
             (fromMaybe "" mStrScheme) 
@@ -279,7 +279,7 @@ parseOptionsFromEnvAndCli localEnvVars envFileSettings =
     eParseResult <- validateCopyAddr <$> OptParse.execParser optionsParserWithInfo
     let results = eEnvFileSettingsOptions ++ [eLocalEnvFlagsOptions, eParseResult]
     if any isLeft results then
-      die (unlines (map show $ lefts results))
+      die ("[ERROR] " ++ unlines (map show $ lefts results))
     else return $ foldl (flip mergeOptions) defaultOptions (rights results)
 
 -- | Parses behavior flags from a list of environment variables. If an

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -401,8 +401,10 @@ parseEnvOptions envVars
       | otherwise = err key
       where sVal = lookupEnvString key
     -- | Lookup a list of strings using ```lookupEnvString```
+    lookupStringList :: String -> Maybe [String]
     lookupStringList key = words <$> lookupEnvString key
     -- | Lookup an log level using ```lookupEnvString```
+    lookupEnvLogLevel :: String -> Maybe LogLevel
     lookupEnvLogLevel key =
       case lookup key envVars of
         Just "info" -> Just Info
@@ -410,6 +412,7 @@ parseEnvOptions envVars
         Nothing -> Nothing
         _ -> err key
     -- | Lookup a boolean flag using ```lookupEnvString```
+    lookupEnvFlag :: String -> Maybe Bool
     lookupEnvFlag key =
       case lookup key envVars of
         Just "true" -> Just True

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -80,7 +80,7 @@ data Validated
 -- not validated by ```isOptionsComplete```
 data UnValidated
 
--- An empty set of options, nothing is specified
+-- | An empty set of options, nothing is specified
 emptyOptions :: Options Validated UnCompleted
 emptyOptions = Options
   { oVaultHost      = Nothing
@@ -174,11 +174,9 @@ data OptionsError
   | InvalidAddrFormat String -- ^ The format of the address is invalid
   | UnknownScheme String -- ^ The scheme of the address is invalid, e.g. ftp://
   | NonNumericPort String -- ^ The port of the address is not an valid integer
-  | HostPortSchemeAddrMismatch -- ^ The host, port and scheme do not match the provided address
-        Bool -- ^ Whether to use TLS or not
-        String -- ^ The host that was given
-        Int -- ^ The port that was given
-        String -- ^The address that was given
+  | HostPortSchemeAddrMismatch Bool String Int String
+      -- ^ The useTls, host, port and scheme do not match the provided address
+
 
 
 

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -2,7 +2,7 @@ module ConfigSpec where
 
 import Test.Hspec
 import Test.QuickCheck
-
+import Data.Either(isRight, isLeft)
 import Config
 
 getHost :: (Maybe String, String, String) -> String
@@ -16,45 +16,64 @@ getPort (_, _, sPort) = sPort
 
 spec :: SpecWith ()
 spec =
-    describe "Split addr" $ do
-        it "should accept http schemes "
-            (
-                getScheme (splitAddress "http://localhost:80") `shouldBe` Just "http://"
-            )
-        it "should accept https schemes "
-            (
-                getScheme (splitAddress "https://localhost:80") `shouldBe` Just "https://"
-            )
-        it "should reject any other scheme"
-            (
-                property $ \scheme -> scheme `notElem` ["http", "https"]
-                    ==> getScheme (splitAddress $ scheme ++ "://localhost:80") `shouldBe` Nothing
-            )
-        it "should parse any host"
-            (
-                property (\host ->
-                    let
-                        addr :: String
-                        addr = "http://" ++ (host :: String) ++ ":80"
-                    in getHost (splitAddress addr) `shouldBe` host
-                )
-
-            )
-        it "should parse any port"
-            (
-                property (\port ->
-                    let
-                        addr :: String
-                        addr = "http://localhost:" ++ port
-                    in ':' `notElem` port ==> getPort (splitAddress addr) `shouldBe` port
-                )
-            )
-        it "should parse any addr"
-            (
-                property (\host port ->
-                    let
-                        addr :: String
-                        addr = "http://" ++ host ++ ":" ++ port
-                    in ':' `notElem` port ==> splitAddress addr `shouldBe` (Just "http://", host, port)
-                )
-            )
+  describe "Split addr" $ do
+    it "should accept http schemes " $
+      getScheme (splitAddress "http://localhost:80") `shouldBe` Just "http://"
+    it "should accept https schemes " $
+      getScheme (splitAddress "https://localhost:80") `shouldBe` Just "https://"
+    it "should reject any other scheme" $
+      property $ \scheme -> scheme `notElem` ["http", "https"]
+        ==> getScheme (splitAddress $ scheme ++ "://localhost:80") `shouldBe` Nothing
+    it "should parse any host" $
+      property (\host ->
+        let
+          addr :: String
+          addr = "http://" ++ (host :: String) ++ ":80"
+        in getHost (splitAddress addr) `shouldBe` host
+      )
+    it "should parse any port" $
+      property (\port ->
+        let
+          addr :: String
+          addr = "http://localhost:" ++ port
+        in ':' `notElem` port ==> getPort (splitAddress addr) `shouldBe` port
+      )
+    it "should parse any addr" $
+      property (\host port ->
+        let
+          addr :: String
+          addr = "http://" ++ host ++ ":" ++ port
+        in ':' `notElem` port ==> splitAddress addr `shouldBe` (Just "http://", host, port)
+      )
+    it "should accept the default configuration" $
+      isRight (validateCopyAddr "" $ castOptions defaultOptions)
+    it "should reject mismatched port" $
+      let
+        options = defaultOptions{
+          oVaultPort = Just 1234
+        }
+      in isLeft (validateCopyAddr "" $ castOptions options)
+    it "should reject mismatched host" $
+      let
+        options = defaultOptions{
+          oVaultHost = Just "invalid_host"
+        }
+      in isLeft (validateCopyAddr "" $ castOptions options)
+    it "should reject mismatched TLS" $
+      let
+        options = defaultOptions{
+          oConnectTls = Just False
+        }
+      in isLeft (validateCopyAddr "" $ castOptions options)
+    it "should reject invalid schemes" $
+      let
+        options = defaultOptions{
+          oVaultAddr = Just "ftp://localhost:8200"
+        }
+      in isLeft (validateCopyAddr "" $ castOptions options)
+    it "should reject non-numeric ports" $
+      let
+        options = defaultOptions{
+          oVaultAddr = Just "https://localhost:myport"
+        }
+      in isLeft (validateCopyAddr "" $ castOptions options)

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -1,0 +1,60 @@
+module ConfigSpec where
+
+import Test.Hspec
+import Test.QuickCheck
+
+import Config
+
+getHost :: (Maybe String, String, String) -> String
+getHost (_, host, _) = host
+
+getScheme :: (Maybe String, String, String) -> Maybe String
+getScheme (mScheme, _, _) = mScheme
+
+getPort :: (Maybe String, String, String) -> String
+getPort (_, _, sPort) = sPort
+
+spec :: SpecWith ()
+spec =
+    describe "Split addr" $ do
+        it "should accept http schemes "
+            (
+                getScheme (splitAddress "http://localhost:80") `shouldBe` Just "http://"
+            )
+        it "should accept https schemes "
+            (
+                getScheme (splitAddress "https://localhost:80") `shouldBe` Just "https://"
+            )
+        it "should reject any other scheme"
+            (
+                property $ \scheme -> scheme `notElem` ["http", "https"]
+                    ==> getScheme (splitAddress $ scheme ++ "://localhost:80") `shouldBe` Nothing
+            )
+        it "should parse any host"
+            (
+                property (\host ->
+                    let
+                        addr :: String
+                        addr = "http://" ++ (host :: String) ++ ":80"
+                    in getHost (splitAddress addr) `shouldBe` host
+                )
+
+            )
+        it "should parse any port"
+            (
+                property (\port ->
+                    let
+                        addr :: String
+                        addr = "http://localhost:" ++ port
+                    in ':' `notElem` port ==> getPort (splitAddress addr) `shouldBe` port
+                )
+            )
+        it "should parse any addr"
+            (
+                property (\host port ->
+                    let
+                        addr :: String
+                        addr = "http://" ++ host ++ ":" ++ port
+                    in ':' `notElem` port ==> splitAddress addr `shouldBe` (Just "http://", host, port)
+                )
+            )

--- a/test/integration/environment_inherritance.sh
+++ b/test/integration/environment_inherritance.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 echo "1..2"
 
 export TEST_VAR="willbeset"
@@ -10,10 +8,15 @@ stack exec -- vaultenv \
   --host ${VAULT_HOST} \
   --port ${VAULT_PORT} \
   --secrets-file ${VAULT_SEEDS} \
+  --inherit-env \
   /usr/bin/env \
   | grep "TEST_VAR"
 
-echo "ok 1 - vaultenv passed through test var"
+if [ $? -eq 0 ]; then
+  echo "ok 1 - vaultenv passed through test var"
+else
+  echo "not ok 1 - vaultenv didn´t pass through test var"
+fi
 
 stack exec -- vaultenv \
   --no-connect-tls \
@@ -24,4 +27,9 @@ stack exec -- vaultenv \
   /usr/bin/env \
   | grep -v "TEST_VAR"
 
-echo "ok 2 - vaultenv didn't pass through test var"
+if [ $? -eq 0 ]; then
+  echo "ok 2 - vaultenv didn't pass through test var"
+else
+  echo "not ok 2 - vaultenv passed through test var"
+fi
+

--- a/test/integration/environment_inherritance.sh
+++ b/test/integration/environment_inherritance.sh
@@ -32,4 +32,3 @@ if [ $? -eq 0 ]; then
 else
   echo "not ok 2 - vaultenv passed through test var"
 fi
-

--- a/test/integration/invalid_addr.sh
+++ b/test/integration/invalid_addr.sh
@@ -2,6 +2,7 @@
 
 echo "1..5"
 
+#test if the addr is accepted when the same as the host, port and scheme (no tls)
 stack exec -- vaultenv \
   --no-connect-tls \
   --host ${VAULT_HOST} \
@@ -14,6 +15,7 @@ if [ $? -ne 0 ]; then
   echo "not ok 1 - vaultenv didn't complete"
 fi
 
+#test if the addr is accepted when the same as the host, port and scheme (use tls)
 stack exec -- vaultenv \
   --connect-tls \
   --host ${VAULT_HOST} \
@@ -24,6 +26,7 @@ stack exec -- vaultenv \
 
 echo "ok 2 - vault rejected the scheme"
 
+#test if rejected with a different scheme (https vs no-tls)
 stack exec -- vaultenv \
   --no-connect-tls \
   --host ${VAULT_HOST} \
@@ -34,6 +37,7 @@ stack exec -- vaultenv \
 
 echo "ok 3 - vault rejected the scheme"
 
+#test if rejected with an invalid host
 stack exec -- vaultenv \
   --no-connect-tls \
   --host invalidhost \
@@ -44,6 +48,7 @@ stack exec -- vaultenv \
 
 echo "ok 4 - vault rejected the host"
 
+#test if rejected with an invalid port
 stack exec -- vaultenv \
   --no-connect-tls \
   --host ${VAULT_HOST} \

--- a/test/integration/invalid_addr.sh
+++ b/test/integration/invalid_addr.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+echo "1..5"
+
+stack exec -- vaultenv \
+  --no-connect-tls \
+  --host ${VAULT_HOST} \
+  --port ${VAULT_PORT} \
+  --addr http://${VAULT_HOST}:${VAULT_PORT} \
+  --secrets-file ${VAULT_SEEDS} -- \
+  /bin/echo "ok 1 - vaultenv correctly recognized the addr"
+
+if [ $? -ne 0 ]; then
+  echo "not ok 1 - vaultenv didn't complete"
+fi
+
+stack exec -- vaultenv \
+  --connect-tls \
+  --host ${VAULT_HOST} \
+  --port ${VAULT_PORT} \
+  --secrets-file ${VAULT_SEEDS} \
+  --addr http://${VAULT_HOST}:${VAULT_PORT} \
+  /bin/echo "not ok 2 - this should never print"
+
+echo "ok 2 - vault rejected the scheme"
+
+stack exec -- vaultenv \
+  --no-connect-tls \
+  --host ${VAULT_HOST} \
+  --port ${VAULT_PORT} \
+  --secrets-file ${VAULT_SEEDS} \
+  --addr https://${VAULT_HOST}:${VAULT_PORT} \
+  /bin/echo "not ok 3 - this should never print"
+
+echo "ok 3 - vault rejected the scheme"
+
+stack exec -- vaultenv \
+  --no-connect-tls \
+  --host invalidhost \
+  --port ${VAULT_PORT} \
+  --secrets-file ${VAULT_SEEDS} \
+  --addr http://${VAULT_HOST}:${VAULT_PORT} \
+  /bin/echo "not ok 4 - this should never print"
+
+echo "ok 4 - vault rejected the host"
+
+stack exec -- vaultenv \
+  --no-connect-tls \
+  --host ${VAULT_HOST} \
+  --port 4321 \
+  --secrets-file ${VAULT_SEEDS} \
+  --addr http://${VAULT_HOST}:${VAULT_PORT} \
+  /bin/echo "not ok 5 - this should never print"
+
+echo "ok 5 - vault rejected the port"

--- a/test/integration/invalid_addr.sh
+++ b/test/integration/invalid_addr.sh
@@ -15,7 +15,7 @@ if [ $? -ne 0 ]; then
   echo "not ok 1 - vaultenv didn't complete"
 fi
 
-#test if the addr is accepted when the same as the host, port and scheme (use tls)
+#test if the addr is rejected when the same as the host, port, but different form the scheme (use tls)
 stack exec -- vaultenv \
   --connect-tls \
   --host ${VAULT_HOST} \


### PR DESCRIPTION
Fixes #66.

Added support for VAULT_ADDR to the config files, as well as the command
line arguments. Changed the config parsing process such that everything
is parsed to an Options datatype after which the options are merged. The
addr field is after each separate parsing verified to be correct and the
information is distributed over the UseTLs (HTTP/HTTPS), Host and Port.