### PR TITLE
Static binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.deb
 
 # auto-generated files
-vaultenv.cabal
+*.cabal

--- a/README.md
+++ b/README.md
@@ -357,6 +357,17 @@ stack exec vaultenv -- --token SECRET --secrets-file foo.env /usr/bin/env
 It is possible to `stack build` with `--split-objs` to produce a smaller binary.
 To take full advantage of this, the Stackage snapshot has to be rebuilt.
 
+If you want a static binary, you can install [Nix](https://nixos.org/nix/) and
+run:
+
+```
+$ $(nix-build --no-link -A full-build-script)
+```
+
+That will build vaultenv (and a bunch of dependencies). The final line of the
+output should be a path in `/nix/store` which contains the final vaultenv
+binary.
+
 ## Future work
 
  - Support DNS `SRV` record lookups, so users only need to specify the host

--- a/README.md
+++ b/README.md
@@ -368,6 +368,21 @@ That will build vaultenv (and a bunch of dependencies). The final line of the
 output should be a path in `/nix/store` which contains the final vaultenv
 binary.
 
+## Development
+
+If you want a convenient way to gather the development dependencies of
+`vaultenv`, you can use `nix`.
+
+The repository contains a `default.nix` which will get you `stack` and `vault`.
+You can then use this get a shell with the tools in scope to work on and test
+`vaultenv`.
+
+Get this shell with:
+
+```
+$ nix run
+```
+
 ## Future work
 
  - Support DNS `SRV` record lookups, so users only need to specify the host

--- a/README.md
+++ b/README.md
@@ -357,12 +357,14 @@ stack exec vaultenv -- --token SECRET --secrets-file foo.env /usr/bin/env
 It is possible to `stack build` with `--split-objs` to produce a smaller binary.
 To take full advantage of this, the Stackage snapshot has to be rebuilt.
 
-If you want a static binary, you can install [Nix](https://nixos.org/nix/) and
-run:
+If you want a fully static executable without a runtime dependency on `libc`
+and run GNU/Linux, you can install [Nix](https://nixos.org/nix/) and run:
 
 ```
 $ $(nix-build --no-link -A full-build-script nix/vaultenv-static.nix)
 ```
+
+This has not been tested on any other platform.
 
 That will build vaultenv (and a bunch of dependencies). The final line of the
 output should be a path in `/nix/store` which contains the final vaultenv
@@ -374,8 +376,8 @@ If you want a convenient way to gather the development dependencies of
 `vaultenv`, you can use `nix`.
 
 The repository contains a `default.nix` which will get you `stack` and `vault`.
-You can then use this get a shell with the tools in scope to work on and test
-`vaultenv`.
+You can then use this to get a shell with the tools in scope to work on and
+test `vaultenv`.
 
 Get this shell with:
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ If you want a static binary, you can install [Nix](https://nixos.org/nix/) and
 run:
 
 ```
-$ $(nix-build --no-link -A full-build-script)
+$ $(nix-build --no-link -A full-build-script nix/vaultenv-static.nix)
 ```
 
 That will build vaultenv (and a bunch of dependencies). The final line of the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # How to release `vaultenv`
 
- 1. Build `vautlenv` with `stack`. Run the tests.
+ 1. Build `vaultenv` with `stack`. Run the tests.
  1. Increment the `version` field in `package.yaml`
  1. Create a git commit
  1. Tag: `git tag -a v<VERSION>`. Write a changelog.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,11 @@
 # How to release `vaultenv`
 
+ 1. Build `vautlenv` with `stack`. Run the tests.
  1. Increment the `version` field in `package.yaml`
  1. Create a git commit
  1. Tag: `git tag -a v<VERSION>`. Write a changelog.
  1. `git push origin master --tags`
- 1. Travis now builds a new release.
+ 1. Build a static version of `vaultenv` by following the instructions in
+    `default.nix`.
  1. Go to https://github.com/channable/vaultenv/releases
- 1. Click "Draft a new release"
- 1. Paste the changelog. The binaries should be there already.
+ 1. Click "Draft a new release". Add a binary from the Nix output.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+let
+  pkgs = import ./nix/nixpkgs.nix;
+in
+  pkgs.buildEnv {
+    name = "vaultenv-devenv";
+    paths = [
+      pkgs.stack
+      pkgs.vault
+    ];
+  }
+

--- a/default.nix
+++ b/default.nix
@@ -1,49 +1,78 @@
+# This is the default build script taken from static-haskell-nix.
+# We've adjusted some things and removed some instructions that
+# we didn't have a usecase for.
+#
 # Run using:
 #
-#     $(nix-build --no-link -A fullBuildScript)
+#     $(nix-build --no-link -A full-build-script)
+#
+# The invocation above will build a buildscript and then run it.
+# (The output of `nix-build --no-link -A full-build-script` is a
+# path to the build script. The `$()` invokes the script.)
+#
+# That will:
+#
+#   - Fetch a stackage snapshot and run stack2nix on it. This
+#     yields a bunch of nix derivations of the entire snapshot.
+#     Some of these will be used in the actual build for the
+#     vaultenv package.
+#   - Download or build a GHC compiled with musl and integer-simple.
+#   - Build vaultenv with integer-simple and link everything
+#     statically. Dependencies are taken from stack.yaml in this
+#     repository.
+#
+# The final output of the invocation above will print a Nix store path
+# like `/nix/store/ak6qm8qmb66zwri7y16sqina1pvn0gmz-vaultenv-real-0.10.0`
+# which will contain a fully static vaultenv binary in the `bin/` subdir.
 {
   stack2nix-output-path ? "custom-stack2nix-output.nix",
 }:
 let
-  cabalPackageName = "vaultenv-real";
-  compiler = "ghc865"; # matching stack.yaml
+  cabal-package-name = "vaultenv-real";
+
+  # This has to match the compiler used in the Stackage snapshot.
+  # Update this when the Stackage snapshot changes the version of
+  # GHC it uses.
+  compiler = "ghc865";
 
   # Pin static-haskell-nix version.
   static-haskell-nix = fetchTarball https://github.com/nh2/static-haskell-nix/archive/ff7715e0e13fb3f615e64a8d8c2e43faa4429b0f.tar.gz;
 
-  # Pin nixpkgs version
-  # By default to the one `static-haskell-nix` provides, but you may also give
-  # your own as long as it has the necessary patches, using e.g.
-  #     pkgs = import (fetchTarball https://github.com/nh2/nixpkgs/archive/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa123.tar.gz) {};
+  # Pin the version of nixpkgs to the one from `static-haskell-nix`.
   pkgs = import "${static-haskell-nix}/nixpkgs.nix";
 
+  # Generate a stack2nix script which will download a Stackage + Hackage
+  # snapshot and convert it to Nix derivations for use in our final build
+  # script.
   stack2nix-script = import "${static-haskell-nix}/static-stack2nix-builder/stack2nix-script.nix" {
     inherit pkgs;
-    stack-project-dir = toString ./.; # where stack.yaml is
-    hackageSnapshot = "2019-10-08T00:00:00Z"; # pins e.g. extra-deps without hashes or revisions
+    stack-project-dir = toString ./.;
+    # Also pin the Hackage snapshot to a certain time for extra-deps without
+    # hashes or revisions. Vaultenv doesn't have any, but it's there if it
+    # ever turns out we need it.
+    hackageSnapshot = "2019-10-08T00:00:00Z";
   };
 
   static-stack2nix-builder = import "${static-haskell-nix}/static-stack2nix-builder/default.nix" {
     normalPkgs = pkgs;
     integer-simple = true;
-    inherit cabalPackageName compiler stack2nix-output-path;
-    # disableOptimization = true; # for compile speed
+    cabalPackageName = cabal-package-name;
+    inherit compiler stack2nix-output-path;
   };
 
-  # Full invocation, including pinning `nix` version itself.
-  fullBuildScript = pkgs.writeScript "stack2nix-and-build-script.sh" ''
+  # This build script invokes `nix-build` on this same file using nix build
+  # from a pinned version of nixpkgs. It will build the `static_package`
+  # attribute that we define in the set below.
+  full-build-script = pkgs.writeScript "stack2nix-and-build-script.sh" ''
     #!/usr/bin/env bash
     set -eu -o pipefail
     STACK2NIX_OUTPUT_PATH=$(${stack2nix-script})
     export NIX_PATH=nixpkgs=${pkgs.path}
-    ${pkgs.nix}/bin/nix-build --no-link -A static_package --argstr stack2nix-output-path "$STACK2NIX_OUTPUT_PATH" "$@"
+    ${pkgs.nix}/bin/nix-build --no-link -A static-package --argstr stack2nix-output-path "$STACK2NIX_OUTPUT_PATH" "$@"
   '';
 
 in
   {
-    static_package = static-stack2nix-builder.static_package;
-    inherit fullBuildScript;
-    # For debugging:
-    inherit stack2nix-script;
-    inherit static-stack2nix-builder;
+    inherit full-build-script;
+    static-package = static-stack2nix-builder.static_package;
   }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,49 @@
+# Run using:
+#
+#     $(nix-build --no-link -A fullBuildScript)
+{
+  stack2nix-output-path ? "custom-stack2nix-output.nix",
+}:
+let
+  cabalPackageName = "vaultenv-real";
+  compiler = "ghc865"; # matching stack.yaml
+
+  # Pin static-haskell-nix version.
+  static-haskell-nix = fetchTarball https://github.com/nh2/static-haskell-nix/archive/ff7715e0e13fb3f615e64a8d8c2e43faa4429b0f.tar.gz;
+
+  # Pin nixpkgs version
+  # By default to the one `static-haskell-nix` provides, but you may also give
+  # your own as long as it has the necessary patches, using e.g.
+  #     pkgs = import (fetchTarball https://github.com/nh2/nixpkgs/archive/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa123.tar.gz) {};
+  pkgs = import "${static-haskell-nix}/nixpkgs.nix";
+
+  stack2nix-script = import "${static-haskell-nix}/static-stack2nix-builder/stack2nix-script.nix" {
+    inherit pkgs;
+    stack-project-dir = toString ./.; # where stack.yaml is
+    hackageSnapshot = "2019-10-08T00:00:00Z"; # pins e.g. extra-deps without hashes or revisions
+  };
+
+  static-stack2nix-builder = import "${static-haskell-nix}/static-stack2nix-builder/default.nix" {
+    normalPkgs = pkgs;
+    integer-simple = true;
+    inherit cabalPackageName compiler stack2nix-output-path;
+    # disableOptimization = true; # for compile speed
+  };
+
+  # Full invocation, including pinning `nix` version itself.
+  fullBuildScript = pkgs.writeScript "stack2nix-and-build-script.sh" ''
+    #!/usr/bin/env bash
+    set -eu -o pipefail
+    STACK2NIX_OUTPUT_PATH=$(${stack2nix-script})
+    export NIX_PATH=nixpkgs=${pkgs.path}
+    ${pkgs.nix}/bin/nix-build --no-link -A static_package --argstr stack2nix-output-path "$STACK2NIX_OUTPUT_PATH" "$@"
+  '';
+
+in
+  {
+    static_package = static-stack2nix-builder.static_package;
+    inherit fullBuildScript;
+    # For debugging:
+    inherit stack2nix-script;
+    inherit static-stack2nix-builder;
+  }

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,13 @@
+# Pin the version of nixpkgs to the one from `static-haskell-nix`.
+# This ensures that we only have a single version of nixpkgs. This
+# makes reasoning about the environment a lot easier. We don't want
+# to maintain our own nixpkgs distribution with the patches from the
+# `static-haskell-nix` project.
+#
+# Normally, we wouldn't do something like this, but in this instance
+# we really want a static binary.
+let
+  static-haskell-nix = import ./static-haskell-nix.nix;
+  pkgs = import "${static-haskell-nix}/nixpkgs.nix";
+in
+  pkgs

--- a/nix/static-haskell-nix.nix
+++ b/nix/static-haskell-nix.nix
@@ -1,0 +1,9 @@
+# Pin static-haskell-nix version.
+let
+  static-haskell-nix-rev = "ff7715e0e13fb3f615e64a8d8c2e43faa4429b0f";
+  static-haskell-nix = builtins.fetchTarball {
+    url = "https://github.com/nh2/static-haskell-nix/archive/${static-haskell-nix-rev}.tar.gz";
+    sha256 = "sha256:17ir87i7sah9nixvh25qhzh19bqv3vgnfg4nfy4wv631q4gfj7fb";
+  };
+in
+  static-haskell-nix

--- a/nix/vaultenv-static.nix
+++ b/nix/vaultenv-static.nix
@@ -28,6 +28,8 @@
   stack2nix-output-path ? "custom-stack2nix-output.nix",
 }:
 let
+  # Field from the hpack/cabal file. We append `-real` to work around
+  # vaultenv also being included in `nixpgks`, which leads to conflicts.
   cabal-package-name = "vaultenv-real";
 
   # This has to match the compiler used in the Stackage snapshot.
@@ -51,6 +53,16 @@ let
     hackageSnapshot = "2019-10-08T00:00:00Z";
   };
 
+  # `full-build-script` will eventually build the `static_package` attribute of
+  # this set. Note `nix-build -A static-package` in `full-build-script` and
+  # `static-package` in the `in` of this module.
+  #
+  # The `static_package` attribute boils down to `haskellPackages.vaultenv-real`
+  # with modifications to get static builds to work. `haskellPackages` is
+  # Nixpkgs' infrastructure for Haskell applications and libraries.
+  #
+  # Take a look at `survey/default.nix` in the `static-haskell-nix` repository
+  # if you want to know what patches have been applied to `haskellPackages`.
   static-stack2nix-builder = import "${static-haskell-nix}/static-stack2nix-builder/default.nix" {
     normalPkgs = pkgs;
     integer-simple = true;

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-name: vaultenv
+name: vaultenv-real
 version: 0.10.0
 synopsis: Runs processes with secrets from HashiCorp Vault
 license: BSD3
@@ -36,7 +36,7 @@ executables:
     main: Main.hs
     source-dirs: app
     dependencies:
-      - vaultenv
+      - vaultenv-real
 
 tests:
   vaultenv-test:
@@ -47,7 +47,7 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - vaultenv
+    - vaultenv-real
     - hspec
     - hspec-discover
     - hspec-expectations

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-# Changed the name here because nixpkgs also incldues a vaultenv and we haven't
+# Changed the name here because nixpkgs also includes a vaultenv and we haven't
 # figured out how to mask that when we build vaultenv with nix itself.
 name: vaultenv-real
 version: 0.10.0

--- a/package.yaml
+++ b/package.yaml
@@ -1,3 +1,5 @@
+# Changed the name here because nixpkgs also incldues a vaultenv and we haven't
+# figured out how to mask that when we build vaultenv with nix itself.
 name: vaultenv-real
 version: 0.10.0
 synopsis: Runs processes with secrets from HashiCorp Vault

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -30,7 +30,7 @@ import Data.Either (lefts, rights, isLeft)
 import Data.Version (showVersion)
 import Options.Applicative (value, long, auto, option, metavar, help, flag,
                             str, argument, many)
-import Paths_vaultenv (version) -- Magic to get the version field from cabal.
+import Paths_vaultenv_real (version) -- Magic to get the version field from cabal.
 import System.IO.Error (catchIOError)
 import System.Exit (die)
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -30,7 +30,10 @@ import Data.Either (lefts, rights, isLeft)
 import Data.Version (showVersion)
 import Options.Applicative (value, long, auto, option, metavar, help, flag,
                             str, argument, many)
-import Paths_vaultenv_real (version) -- Magic to get the version field from cabal.
+-- Cabal generates the @Paths_vaultenv_real@ module, which contains a @version@
+-- binding with the value out of the Cabal file. This feature is documented at:
+-- https://www.haskell.org/cabal/users-guide/developing-packages.html#accessing-data-files-from-package-code
+import Paths_vaultenv_real (version)
 import System.IO.Error (catchIOError)
 import System.Exit (die)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,3 @@
+# Also take care to update the compiler in default.nix to the
+# compiler used in this Stackage snapshot.
 resolver: lts-14.7


### PR DESCRIPTION
Fixes https://github.com/channable/vaultenv/issues/43 (Well not for `0.7.1`, but from now on)

I managed to get a static binary build working for vaultenv! Huge thanks is in order to @nh2 for the `static-haskell-nix` project.

Approach:

 - Import the default build script from static-haskell-nix and adjust
   it for our use case.
 - Rename vaultenv to vautlenv-real to work around the fact that nixpkgs
   also contains vaultenv. This was causing conflicts. (There is
   probably a better way to do this, but I didn't figure that out yet.
   If someone reading this knows how we can work around this, we'd
   appreciate any tips.)
 - Tweak the documentation.

Possible downsides:

 - This might break when we add new deps or upgrade to a new stackage snapshot. As `vaultenv` is updated infrequently, I think this is fine.