### PR TITLE
Add option to remove environment variables before executing program

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,13 @@ of `tutorial.sh`.
 ## Usage
 
 ```
-vaultenv - run programs with secrets from HashiCorp Vault
+vaultenv 0.11.0 - run programs with secrets from HashiCorp Vault
 
 Usage: vaultenv [--version] [--host HOST] [--port PORT] [--addr ADDR]
                 [--token TOKEN] [--secrets-file FILENAME] [CMD] [ARGS...]
                 ([--no-connect-tls] | [--connect-tls]) ([--no-validate-certs] |
                 [--validate-certs]) ([--no-inherit-env] | [--inherit-env])
+                [--inherit-env-blacklist COMMA_SEPARATED_NAMES]
                 [--retry-base-delay-milliseconds MILLISECONDS]
                 [--retry-attempts NUM] [--log-level error | info] [--use-path]
 
@@ -142,6 +143,11 @@ Available options:
   --inherit-env            Always merge the parent environment with the secrets
                            file. Default: merge environments. Can be used to
                            override VAULTENV_INHERIT_ENV.
+  --inherit-env-blacklist COMMA_SEPARATED_NAMES
+                           Comma-separated list of environment variable names to
+                           remove from the environment before executing CMD.
+                           Also configurable via VAULTENV_INHERIT_ENV_BLACKLIST.
+                           Has no effect if no-inherit-env is set!
   --retry-base-delay-milliseconds MILLISECONDS
                            Base delay for vault connection retrying. Defaults to
                            40ms. Also configurable via
@@ -155,7 +161,6 @@ Available options:
   --use-path               Use PATH for finding the executable that vaultenv
                            should call. Default: don't search PATH. Also
                            configurable via VAULTENV_USE_PATH.
-
 ```
 
 ## Configuration
@@ -268,20 +273,21 @@ This is useful on development machines. It allows you to:
 This means that any command line option that is present would overwrite any other configuration.
 If an option is not specified, the default is used. The defaults are as follows:
 ```
-VAULT_HOST:                 localhost
-VAULT_PORT:                 8200
-VAULT_ADDR:                 https://localhost:8200
-VAULT_TOKEN:                Unspecified
-VAULTENV_SECRETS_FILE:      Unspecified
-CMD:                        Unspecified
-ARGS:                       []
-VAULTENV_CONNECT_TLS:       True
-VAULTENV_VALIDATE_CERTS:    True
-VAULTENV_INHERIT_ENV:       True
-VAULTENV_RETRY_BASE_DELAY:  40
-VAULTENV_RETRY_ATTEMPTS:    9
-VAULTENV_LOG_LEVEL:         Error
-VAULTENV_USE_PATH:          True
+VAULT_HOST:                     localhost
+VAULT_PORT:                     8200
+VAULT_ADDR:                     https://localhost:8200
+VAULT_TOKEN:                    Unspecified
+VAULTENV_SECRETS_FILE:          Unspecified
+CMD:                            Unspecified
+ARGS:                           []
+VAULTENV_CONNECT_TLS:           True
+VAULTENV_VALIDATE_CERTS:        True
+VAULTENV_INHERIT_ENV:           True
+VAULTENV_INHERIT_ENV_BLACKLIST: []
+VAULTENV_RETRY_BASE_DELAY:      40
+VAULTENV_RETRY_ATTEMPTS:        9
+VAULTENV_LOG_LEVEL:             Error
+VAULTENV_USE_PATH:              True
 ```
 In cases where no default nor any value is specified, which is possible for `Token`, `Secret file` and
 `Command`, Vaultenv will give an error that it requires these values to operate.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -265,8 +265,12 @@ vaultEnv context = do
       buildEnv :: [EnvVar] -> [EnvVar]
       buildEnv secretsEnv =
         if getOptionsValue oInheritEnv . cCliOptions $ context
-        then secretsEnv ++ cLocalEnvVars context
+        then removeBlacklistedVars $ secretsEnv ++ cLocalEnvVars context
         else secretsEnv
+
+        where
+          inheritEnvBlacklist = getOptionsValue oInheritEnvBlacklist . cCliOptions $ context
+          removeBlacklistedVars = filter (not . flip elem inheritEnvBlacklist . fst)
 
 
 runCommand :: Options Validated Completed -> [EnvVar] -> IO a

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -338,7 +338,7 @@ instance Read LogLevel where
 -- | Parse program options from the command line and the process environment.
 parseOptions :: [EnvVar] -> [[EnvVar]] -> IO (Options Validated Completed)
 parseOptions localEnvVars envFileSettings =
-  let eLocalEnvFlagsOptions = validateCopyAddr "local environemnt variables" $ parseEnvOptions localEnvVars
+  let eLocalEnvFlagsOptions = validateCopyAddr "local environment variables" $ parseEnvOptions localEnvVars
       eEnvFileSettingsOptions = map (validateCopyAddr "environment file" . parseEnvOptions) envFileSettings
   in do
     eParseResult <- validateCopyAddr "cli options" <$> OptParse.execParser parserCliOptions

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -584,7 +584,7 @@ optionsParser = Options
       <> value Nothing
       <> help ("Comma-separated list of environment variable names to remove from " ++
                "the environment before executing CMD. Also configurable via " ++
-               "VAULTENV_INHERIT_ENV_BLACKLIST.")
+               "VAULTENV_INHERIT_ENV_BLACKLIST. Has no effect if no-inherit-env is set!")
 
     baseDelayMs
       =  fmap MilliSeconds <$> option (Just <$> auto)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -61,6 +61,7 @@ data Options validated completed = Options
   , oConnectTls      :: Maybe Bool
   , oValidateCerts   :: Maybe Bool
   , oInheritEnv      :: Maybe Bool
+  , oInheritEnvBlacklist :: Maybe [String]
   , oRetryBaseDelay  :: Maybe MilliSeconds
   , oRetryAttempts   :: Maybe Int
   , oLogLevel        :: Maybe LogLevel
@@ -97,6 +98,7 @@ defaultOptions = Options
   , oConnectTls     = Just True
   , oValidateCerts  = Just True
   , oInheritEnv     = Just True
+  , oInheritEnvBlacklist = Just []
   , oRetryBaseDelay = Just (MilliSeconds 40)
   , oRetryAttempts  = Just 9
   , oLogLevel       = Just Error
@@ -117,6 +119,7 @@ castOptions opts = Options
   , oConnectTls     = oConnectTls opts
   , oValidateCerts  = oValidateCerts opts
   , oInheritEnv     = oInheritEnv opts
+  , oInheritEnvBlacklist = oInheritEnvBlacklist opts
   , oRetryBaseDelay = oRetryBaseDelay opts
   , oRetryAttempts  = oRetryAttempts opts
   , oLogLevel       = oLogLevel opts
@@ -135,6 +138,7 @@ instance Show (Options valid complete) where
     , "Use TLS:        " ++ showSpecified (oConnectTls opts)
     , "Validate certs: " ++ showSpecified (oValidateCerts opts)
     , "Inherit env:    " ++ showSpecified (oInheritEnv opts)
+    , "Inherit env blacklist: " ++ showSpecified (oInheritEnvBlacklist opts)
     , "Base delay:     " ++ showSpecified (unMilliSeconds <$> oRetryBaseDelay opts)
     , "Retry attempts: " ++ showSpecified (oRetryAttempts opts)
     , "Log-level:      " ++ showSpecified (oLogLevel opts)
@@ -242,6 +246,7 @@ mergeOptions opts1 opts2 = let
   , oConnectTls     = combine oConnectTls
   , oValidateCerts  = combine oValidateCerts
   , oInheritEnv     = combine oInheritEnv
+  , oInheritEnvBlacklist = combine oInheritEnvBlacklist
   , oRetryBaseDelay = combine oRetryBaseDelay
   , oRetryAttempts  = combine oRetryAttempts
   , oLogLevel       = combine oLogLevel
@@ -366,6 +371,7 @@ parseEnvOptions envVars
   , oConnectTls     = lookupEnvFlag     "VAULTENV_CONNECT_TLS"
   , oValidateCerts  = lookupEnvFlag     "VAULTENV_VALIDATE_CERTS"
   , oInheritEnv     = lookupEnvFlag     "VAULTENV_INHERIT_ENV"
+  , oInheritEnvBlacklist = lookupCommaSeparatedList "VAULTENV_INHERIT_ENV_BLACKLIST"
   , oRetryBaseDelay = MilliSeconds <$> lookupEnvInt      "VAULTENV_RETRY_BASE_DELAY"
   , oRetryAttempts  = lookupEnvInt      "VAULTENV_RETRY_ATTEMPTS"
   , oLogLevel       = lookupEnvLogLevel "VAULTENV_LOG_LEVEL"
@@ -388,6 +394,9 @@ parseEnvOptions envVars
     -- | Lookup a list of strings using ```lookupEnvString```
     lookupStringList :: String -> Maybe [String]
     lookupStringList key = words <$> lookupEnvString key
+    -- | Lookup a comma-separated list of strings using ```lookupEnvString```
+    lookupCommaSeparatedList :: String -> Maybe [String]
+    lookupCommaSeparatedList key = splitOn ',' <$> lookupEnvString key
     -- | Lookup an log level using ```lookupEnvString```
     lookupEnvLogLevel :: String -> Maybe LogLevel
     lookupEnvLogLevel key =
@@ -481,6 +490,7 @@ optionsParser = Options
     <*> (noConnectTls    <|> connectTls)
     <*> (noValidateCerts <|> validateCerts)
     <*> (noInheritEnv    <|> inheritEnv)
+    <*> inheritEnvBlacklist
     <*> baseDelayMs
     <*> retryAttempts
     <*> logLevel
@@ -563,6 +573,19 @@ optionsParser = Options
       $  long "inherit-env"
       <> help ("Always merge the parent environment with the secrets file. Default: " ++
                 "merge environments. Can be used to override VAULTENV_INHERIT_ENV.")
+
+    maybeStrList = Just . splitOn ',' <$> str
+    maybeStrListOption = option maybeStrList
+
+    inheritEnvBlacklist
+      = maybeStrListOption
+      $ long "inherit-env-blacklist"
+      <> metavar "COMMA_SEPARATED_NAMES"
+      <> value Nothing
+      <> help ("Comma-separated list of environment variable names to remove from " ++
+               "the environment before executing CMD. Also configurable via " ++
+               "VAULTENV_INHERIT_ENV_BLACKLIST.")
+
     baseDelayMs
       =  fmap MilliSeconds <$> option (Just <$> auto)
       (  long "retry-base-delay-milliseconds"
@@ -592,6 +615,18 @@ optionsParser = Options
       <> help ("Use PATH for finding the executable that vaultenv should call. Default: " ++
               "don't search PATH. Also configurable via VAULTENV_USE_PATH.")
 
+-- | Split a list of elements on the given separator, returning sublists without this
+-- separator item.
+--
+-- Example:
+--
+-- >>> splitOn ',' "somestring,anotherstring"
+-- ["somestring", "anotherstring"]
+splitOn :: (Eq a) => a -> [a] -> [[a]]
+splitOn sep x
+  = case span (/= sep) x of
+    (y, []) -> [y]
+    (y, ys) -> y : splitOn sep (tail ys)
 
 -- | Search for environment files in default locations and load them in order.
 --

--- a/test/integration/inherit-env-blacklist-both.sh
+++ b/test/integration/inherit-env-blacklist-both.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "1..4"
+
+testing_keys_present() {
+    stack exec -- vaultenv \
+        --no-connect-tls \
+        --host ${VAULT_HOST} \
+        --port ${VAULT_PORT} \
+        --secrets-file ${VAULT_SEEDS} \
+        "$@" \
+        /usr/bin/env | grep --count -e "TESTING_KEY=testing42" -e "VAULT_TOKEN=integration"
+}
+
+# Test that the variables are present when no blacklist is used.
+if [[ $(testing_keys_present) -eq 2 ]]; then
+    echo "ok 1 - keys present when not blacklisted"
+else
+    echo "not ok 1 - keys absent while not blacklisted"
+fi
+
+# Test that blacklisting secrets via the `--inherit-env-blacklist` argument works
+if [[ $(testing_keys_present --inherit-env-blacklist VAULT_TOKEN,TESTING_KEY) -eq 0 ]]; then
+    echo "ok 2 - keys absent when blacklisted via argument"
+else
+    echo "not ok 2 - keys present while blacklisted via argument"
+fi
+
+# Test that blacklisting via the environment variable works.
+export VAULTENV_INHERIT_ENV_BLACKLIST=VAULT_TOKEN,TESTING_KEY
+if [[ $(testing_keys_present) -eq 0 ]]; then
+    echo "ok 3 - keys absent when blacklisted via environment"
+else
+    echo "not ok 3 - keys present while blacklisted via environment"
+fi
+unset VAULTENV_INHERIT_ENV_BLACKLIST
+
+# Test that blacklisting via the .env config file works.
+echo "VAULTENV_INHERIT_ENV_BLACKLIST=VAULT_TOKEN,TESTING_KEY" > .env
+if [[ $(testing_keys_present) -eq 0 ]]; then
+    echo "ok 4 - keys absent when blacklisted via config file"
+else
+    echo "not ok 4 - keys present while blacklisted via config file"
+fi
+rm .env

--- a/test/integration/inherit-env-blacklist-existing.sh
+++ b/test/integration/inherit-env-blacklist-existing.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "1..4"
+
+TEMP_RUN_DIRECTORY=$(mktemp -d)
+vault_token_present() {
+    stack exec --cwd $TEMP_RUN_DIRECTORY -- vaultenv \
+        --no-connect-tls \
+        --host ${VAULT_HOST} \
+        --port ${VAULT_PORT} \
+        --secrets-file ${VAULT_SEEDS} \
+        "$@" \
+        /usr/bin/env | grep --count "VAULT_TOKEN=integration"
+}
+
+## Test blacklisting a variable from the outer environment (VAULT_TOKEN).
+# Test that the variable is present when no blacklist is used.
+if [[ $(vault_token_present) -eq 1 ]]; then
+    echo "ok 1 - VAULT_TOKEN present when not blacklisted"
+else
+    echo "not ok 1 - VAULT_TOKEN absent while not blacklisted"
+fi
+
+# Test that blacklisting secrets via the `--inherit-env-blacklist` argument works
+if [[ $(vault_token_present --inherit-env-blacklist VAULT_TOKEN) -eq 0 ]]; then
+    echo "ok 2 - VAULT_TOKEN absent when blacklisted via argument"
+else
+    echo "not ok 2 - VAULT_TOKEN present while blacklisted via argument"
+fi
+
+# # Test that blacklisting via the environment variable works.
+export VAULTENV_INHERIT_ENV_BLACKLIST=VAULT_TOKEN
+if [[ $(vault_token_present) -eq 0 ]]; then
+    echo "ok 3 - VAULT_TOKEN absent when blacklisted via environment"
+else
+    echo "not ok 3 - VAULT_TOKEN present while blacklisted via environment"
+fi
+unset VAULTENV_INHERIT_ENV_BLACKLIST
+
+# Test that blacklisting via the .env config file works.
+echo "VAULTENV_INHERIT_ENV_BLACKLIST=VAULT_TOKEN" > "${TEMP_RUN_DIRECTORY}/.env"
+if [[ $(vault_token_present) -eq 0 ]]; then
+    echo "ok 4 - VAULT_TOKEN absent when blacklisted via config file"
+else
+    echo "not ok 4 - VAULT_TOKEN present while blacklisted via config file"
+fi
+rm "${TEMP_RUN_DIRECTORY}/.env"

--- a/test/integration/inherit-env-blacklist-secret.sh
+++ b/test/integration/inherit-env-blacklist-secret.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "1..4"
+
+TEMP_RUN_DIRECTORY=$(mktemp -d)
+testing_key_present() {
+    stack exec --cwd $TEMP_RUN_DIRECTORY -- vaultenv \
+        --no-connect-tls \
+        --host ${VAULT_HOST} \
+        --port ${VAULT_PORT} \
+        --secrets-file ${VAULT_SEEDS} \
+        "$@" \
+        /usr/bin/env | grep --count "TESTING_KEY=testing42"
+}
+
+## Test blacklisting a variable that would normally be set by Vaultenv itself (TESTING_KEY).
+# Test that the variable is present when no blacklist is used.
+if [[ $(testing_key_present) -eq 1 ]]; then
+    echo "ok 1 - TESTING_KEY present when not blacklisted"
+else
+    echo "not ok 1 - TESTING_KEY absent while not blacklisted"
+fi
+
+# Test that blacklisting secrets via the `--inherit-env-blacklist` argument works
+if [[ $(testing_key_present --inherit-env-blacklist TESTING_KEY) -eq 0 ]]; then
+    echo "ok 2 - TESTING_KEY absent when blacklisted via argument"
+else
+    echo "not ok 2 - TESTING_KEY present while blacklisted via argument"
+fi
+
+# # Test that blacklisting via the environment variable works.
+export VAULTENV_INHERIT_ENV_BLACKLIST=TESTING_KEY
+if [[ $(testing_key_present) -eq 0 ]]; then
+    echo "ok 3 - TESTING_KEY absent when blacklisted via environment"
+else
+    echo "not ok 3 - TESTING_KEY present while blacklisted via environment"
+fi
+unset VAULTENV_INHERIT_ENV_BLACKLIST
+
+# Test that blacklisting via the .env config file works.
+echo "VAULTENV_INHERIT_ENV_BLACKLIST=TESTING_KEY" > "${TEMP_RUN_DIRECTORY}/.env"
+if [[ $(testing_key_present) -eq 0 ]]; then
+    echo "ok 4 - TESTING_KEY absent when blacklisted via config file"
+else
+    echo "not ok 4 - TESTING_KEY present while blacklisted via config file"
+fi
+rm "${TEMP_RUN_DIRECTORY}/.env"


### PR DESCRIPTION
This PR adds the option `--inherit-env-blacklist` to Vaultenv.

This option takes a comma-separated list of environment variable names, and when
defined these environment variables are removed from the environment before Vaultenv
executes the command to run.

This option does not implicitly enable `--inherit-env`, and the blacklist is not
applied if `--inherit-env` is `false` (we could change `buildEnv` so it does if this
is desired).
No warning is given if a variable defined in the secrets file is removed by this
blacklist.

Example usage:

```console
$ stack run -- --secrets-file /tmp/dummy-file env | grep VAULT_
VAULT_TOKEN=present-in-environment
VAULT_HOST=127.0.0.1
VAULT_PORT=8200

$ # Filter Vault token from environment
$ stack run -- --secrets-file /tmp/dummy-file --inherit-env-blacklist VAULT_TOKEN,VAULT_HOST env | grep VAULT_
VAULT_PORT=8200

$ # Equivalent (but does cause the blacklist to end up in the environment):
$ VAULTENV_INHERIT_ENV_BLACKLIST=VAULT_TOKEN,VAULT_HOST stack run -- --secrets-file /tmp/dummy-file env | grep VAULT_
VAULTENV_INHERIT_ENV_BLACKLIST=VAULT_TOKEN,VAULT_HOST
VAULT_PORT=8200
```

Fixes #83