### PR TITLE
Build .deb package with static binary from Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 /.stack-work
 *.deb
+/package/vaultenv-*-linux-musl
 
 # auto-generated files
 *.cabal

--- a/README.md
+++ b/README.md
@@ -376,6 +376,19 @@ That will build vaultenv (and a bunch of dependencies). The final line of the
 output should be a path in `/nix/store` which contains the final vaultenv
 binary.
 
+It is possible to speed up the compilation process by copying some dependencies
+from a Nix cache, to not have to recompile all of Haskell and its dependencies.
+To set up the cache, execute these commands once before building:
+
+```console
+$ nix run -c cachix use static-haskell-nix
+$ nix run -c cachix use channable-public
+```
+
+Note that the build process via Nix is not (yet) reproducible, which means that
+different builds of the same source code may result in different Nix derivation
+hashes.
+
 ## Development
 
 If you want a convenient way to gather the development dependencies of

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,9 @@
  1. Create a git commit
  1. Tag: `git tag -a v<VERSION>`. Write a changelog.
  1. `git push origin master --tags`
- 1. Build a static version of `vaultenv` by following the instructions in
-    `default.nix`.
+ 1. `cd package`
+ 1. Build the static version of `vaultenv` and the Debian package by running
+    `./build_package.sh`.
  1. Go to https://github.com/channable/vaultenv/releases
- 1. Click "Draft a new release". Add a binary from the Nix output.
+ 1. Click "Draft a new release". Add the binary from the Nix output and the
+    .deb package.

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ in
     paths = [
       pkgs.stack
       pkgs.vault
+	  pkgs.cachix
     ];
   }
 

--- a/package/build_package.sh
+++ b/package/build_package.sh
@@ -14,7 +14,7 @@ set -euf -o pipefail
 
 # Get the package version from Stack, eliminate the single quotes.
 # Exported, because it is used with envsubst to write the control file.
-export VERSION=$(stack query locals vaultenv version | sed -e "s/^'//" -e "s/'$//")
+export VERSION=$(stack query locals vaultenv-real version | sed -e "s/^'//" -e "s/'$//")
 
 # The name of the .deb file to create
 PKGNAME="vaultenv-${VERSION}"

--- a/package/build_package.sh
+++ b/package/build_package.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# This script builds a .deb package from the binaries in the .stack-work
-# directory.
+# This script builds a .deb package from the static binary build by Nix.
 #
 #   Usage: ./scripts/build_package.sh
 
@@ -24,10 +23,12 @@ mkdir -p "$PKGNAME/DEBIAN"
 mkdir -p "$PKGNAME/usr/bin"
 mkdir -p "$PKGNAME/etc/secrets.d"
 
-stack build
-stack install
-cp "$(stack path --local-install-root)/bin/vaultenv" "$PKGNAME/usr/bin/"
-cp "$(stack path --local-install-root)/bin/vaultenv" vaultenv-${VERSION}_x86_64-ubuntu-linux
+cd ..
+VAULTENV_NIX_PATH=$($(nix-build --no-link -A full-build-script nix/vaultenv-static.nix) | tail -n1)
+cd -
+
+cp "${VAULTENV_NIX_PATH}/bin/vaultenv" "$PKGNAME/usr/bin/"
+cp "${VAULTENV_NIX_PATH}/bin/vaultenv" "vaultenv-${VERSION}-linux-musl"
 
 # Write the package metadata file, substituting environment variables in the
 # template file.

--- a/package/build_package.sh
+++ b/package/build_package.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script builds a .deb package from the binaries in the .stack-work
+# directory.
+#
+#   Usage: ./scripts/build_package.sh
+
+# Safe scripting options:
+#  - `e` for fail on nonzero exit of any command
+#  - `u` for fail on unset variables
+#  - `f` to disable globbing
+#  - `o pipefail` for error on failed pipes
+set -euf -o pipefail
+
+# Get the package version from Stack, eliminate the single quotes.
+# Exported, because it is used with envsubst to write the control file.
+export VERSION=$(stack query locals vaultenv version | sed -e "s/^'//" -e "s/'$//")
+
+# The name of the .deb file to create
+PKGNAME="vaultenv-${VERSION}"
+
+# Recreate the file system layout as it should be on the target machine.
+mkdir -p "$PKGNAME/DEBIAN"
+mkdir -p "$PKGNAME/usr/bin"
+mkdir -p "$PKGNAME/etc/secrets.d"
+
+stack build
+stack install
+cp "$(stack path --local-install-root)/bin/vaultenv" "$PKGNAME/usr/bin/"
+cp "$(stack path --local-install-root)/bin/vaultenv" vaultenv-${VERSION}_x86_64-ubuntu-linux
+
+# Write the package metadata file, substituting environment variables in the
+# template file.
+cat deb_control | envsubst > "$PKGNAME/DEBIAN/control"
+
+# Build the Debian package
+dpkg-deb --build "$PKGNAME"
+
+# Clean up temporary files
+rm -fr "$PKGNAME"

--- a/package/deb_control
+++ b/package/deb_control
@@ -1,0 +1,11 @@
+Package: vaultenv
+Version: ${VERSION}
+Priority: optional
+Architecture: amd64
+Maintainer: Laurens Duijvesteijn <laurens@channable.com>
+Description: Run processes with secrets from HashiCorp Vault
+Depends: libc6,
+         libgmp10,
+         libgcc1,
+         zlib1g,
+         netbase

--- a/package/deb_control
+++ b/package/deb_control
@@ -4,8 +4,3 @@ Priority: optional
 Architecture: amd64
 Maintainer: Laurens Duijvesteijn <laurens@channable.com>
 Description: Run processes with secrets from HashiCorp Vault
-Depends: libc6,
-         libgmp10,
-         libgcc1,
-         zlib1g,
-         netbase


### PR DESCRIPTION
This PR brings back the scripts to build a .deb package for Vaultenv, after it was
removed in 9fb4125. The scripts have been altered to use the static binary built by
Nix, which means that we can publish the .deb without any dependencies and it should
work on any Debian / Ubuntu derivative.