### PR TITLE
Fix retry behavior

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Applicative    ((<|>))
-import Control.Exception      (Exception, catch)
+import Control.Exception      (catch)
 import Control.Monad          (forM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson             (FromJSON, (.:))
@@ -172,8 +172,6 @@ data VaultError
   | DuplicateVar String
   | Unspecified Int LBS.ByteString
   deriving Show
-
-instance Exception VaultError
 
 -- | Retry configuration to use for network requests to Vault.
 -- We use a limited exponential backoff with the policy

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -252,7 +252,7 @@ vaultEnv context = do
     Right mountInfo' -> do
       secrets <- readSecretsFile secretFile
       case secrets of
-        Left error -> throw error
+        Left error -> return $ Left $ SecretFileError error
         Right secrets' -> do
           secretEnv <- requestSecrets context mountInfo' secrets'
           case secretEnv of

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -209,8 +209,7 @@ main = do
                         , cHttpManager = httpManager
                         }
 
-  envVars <- vaultEnv context
-  case envVars of
+  vaultEnv context >>= \case
     Left err -> Exit.die (vaultErrorLogMessage err)
     Right newEnv -> runCommand cliAndEnvAndEnvFileOptions newEnv
 
@@ -288,6 +287,7 @@ vaultEnv context = do
       -- We also edit the Request contained in the exception to remove the
       -- Vault token, as it would otherwise get printed to stderr if we error
       -- out.
+      httpErrorHandler :: HttpException -> IO (Either VaultError b)
       httpErrorHandler (e :: HttpException) = case e of
         (HttpExceptionRequest request reason) ->
           let sanitizedRequest = sanitizeRequest request

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -208,12 +208,7 @@ doWithRetries retryPolicy = Retry.retrying retryPolicy isRetryableFailure
     -- actions to perform are in IO as well.
     isRetryableFailure :: Retry.RetryStatus -> Either VaultError a -> IO Bool
     isRetryableFailure _retryStatus (Right _) = pure False
-    isRetryableFailure retryStatus (Left err) = shouldRetry retryStatus err
-
-    -- | Determine whether a request that resulted in the given VaultError
-    -- should be retried.
-    shouldRetry :: Applicative f => Retry.RetryStatus -> VaultError -> f Bool
-    shouldRetry _retryStatus res = pure $ case res of
+    isRetryableFailure _retryStatus (Left err) = pure $ case err of
       ServerError _ -> True
       ServerUnavailable _ -> True
       ServerUnreachable _ -> True

--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,6 @@ dependencies:
   - http-conduit
   - http-client
   - megaparsec
-  - mtl
   - optparse-applicative
   - parser-combinators
   - retry

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ dependencies:
   - utf8-string
   - optparse-applicative
 
-# ghc-options: -Wall -Werror
+ghc-options: -Wall -Werror
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ dependencies:
   - utf8-string
   - optparse-applicative
 
-ghc-options: -Wall -Werror
+# ghc-options: -Wall -Werror
 
 library:
   source-dirs: src

--- a/src/SecretsFile.hs
+++ b/src/SecretsFile.hs
@@ -23,7 +23,6 @@ module SecretsFile where
 
 import Control.Applicative.Combinators (some, option, optional)
 import Control.Exception (Exception, try, displayException)
-import Control.Monad.Except (MonadError, MonadIO, liftEither, liftIO)
 import Data.Char (toUpper, isSpace, isControl)
 import Data.Functor (void)
 import Data.List (intercalate)
@@ -58,10 +57,6 @@ instance Show SFError where
     ParseErr pe -> MP.errorBundlePretty pe
 
 instance Exception SFError
-
--- | Helper for ExceptT stuff that we use in app/Main.hs
-readSecretList :: (MonadError SFError m, MonadIO m) => FilePath -> m [Secret]
-readSecretList fp = liftEither =<< (liftIO $ readSecretsFile fp)
 
 -- | Read a list of secrets from a file
 readSecretsFile :: FilePath -> IO (Either SFError [Secret])

--- a/src/SecretsFile.hs
+++ b/src/SecretsFile.hs
@@ -22,7 +22,7 @@ If you are user, please see the README for more information.
 module SecretsFile where
 
 import Control.Applicative.Combinators (some, option, optional)
-import Control.Exception (Exception, try, displayException)
+import Control.Exception (try, displayException)
 import Data.Char (toUpper, isSpace, isControl)
 import Data.Functor (void)
 import Data.List (intercalate)
@@ -55,8 +55,6 @@ instance Show SFError where
   show sfErr = case sfErr of
     IOErr ioErr -> displayException ioErr
     ParseErr pe -> MP.errorBundlePretty pe
-
-instance Exception SFError
 
 -- | Read a list of secrets from a file
 readSecretsFile :: FilePath -> IO (Either SFError [Secret])

--- a/src/SecretsFile.hs
+++ b/src/SecretsFile.hs
@@ -22,7 +22,7 @@ If you are user, please see the README for more information.
 module SecretsFile where
 
 import Control.Applicative.Combinators (some, option, optional)
-import Control.Exception (try, displayException)
+import Control.Exception (Exception, try, displayException)
 import Control.Monad.Except (MonadError, MonadIO, liftEither, liftIO)
 import Data.Char (toUpper, isSpace, isControl)
 import Data.Functor (void)
@@ -56,6 +56,8 @@ instance Show SFError where
   show sfErr = case sfErr of
     IOErr ioErr -> displayException ioErr
     ParseErr pe -> MP.errorBundlePretty pe
+
+instance Exception SFError
 
 -- | Helper for ExceptT stuff that we use in app/Main.hs
 readSecretList :: (MonadError SFError m, MonadIO m) => FilePath -> m [Secret]

--- a/test/integration/retry_tests.py
+++ b/test/integration/retry_tests.py
@@ -1,0 +1,194 @@
+#!/usr/bin/python3.7
+"""
+Tests whether the retry mechanism in Vaultenv works correctly by starting Vaultenv
+before the Vault server is ready. Runs after the rest of the tests in
+integration_test.sh, and requires that there is no Vault server running.
+
+Requires these environment variables (should all be set by integration_test.sh):
+  - VAULT_ADDR, VAULT_HOST, VAULT_PORT, VAULT_TOKEN: Credentials to connect to development Vault
+  - VAULT_SEEDS, VAULT_SEEDS_V2: Paths to a V1 and V2 secrets file
+"""
+
+import os
+import signal
+import subprocess
+from pathlib import Path
+from time import sleep
+from typing import Set
+
+import tap
+
+
+def main() -> None:
+    v1_secrets_file = Path(os.environ["VAULT_SEEDS"])
+    v2_secrets_file = Path(os.environ["VAULT_SEEDS_V2"])
+
+    tap.plan(4)
+
+    tap.diagnose("Starting Vaultenv processes")
+    v1_handle = run_vaultenv(v1_secrets_file)
+    v2_handle = run_vaultenv(v2_secrets_file)
+
+    sleep(5)
+    tap.diagnose("Pausing Vaultenv processes")
+    v1_handle.send_signal(signal.SIGSTOP)
+    v2_handle.send_signal(signal.SIGSTOP)
+
+    tap.diagnose("Starting Vault server")
+    vault_server = run_vault_server()
+    sleep(5)
+
+    tap.diagnose("Resuming Vaultenv processes")
+    v1_handle.send_signal(signal.SIGCONT)
+    v2_handle.send_signal(signal.SIGCONT)
+
+    check_vaultenv_result(v1_handle, secrets_version=1, api_version=1)
+    check_vaultenv_result(v2_handle, secrets_version=2, api_version=1)
+
+    # We need to kill and restart the server or the kernel will accept the TCP
+    # connections while the Vault server is paused.
+    vault_server.terminate()
+    vault_server.wait(timeout=5)
+
+    tap.diagnose("Starting Vaultenv processes")
+    v1_handle = run_vaultenv(v1_secrets_file)
+    v2_handle = run_vaultenv(v2_secrets_file)
+    sleep(5)
+
+    tap.diagnose("Pausing Vaultenv processes")
+    v1_handle.send_signal(signal.SIGSTOP)
+    v2_handle.send_signal(signal.SIGSTOP)
+
+    tap.diagnose("Starting Vault server")
+    vault_server = run_vault_server()
+    sleep(5)
+
+    tap.diagnose("Resuming Vaultenv processes")
+    v1_handle.send_signal(signal.SIGCONT)
+    v2_handle.send_signal(signal.SIGCONT)
+
+    check_vaultenv_result(v1_handle, secrets_version=1, api_version=2)
+    check_vaultenv_result(v2_handle, secrets_version=2, api_version=2)
+
+    tap.diagnose("Killing Vault server")
+    vault_server.terminate()
+    vault_server.wait(timeout=10)
+
+def run_vaultenv(secrets_file: Path) -> subprocess.Popen:
+    """
+    Run Vaultenv with the secrets file from the given path.
+
+    Return a subprocess.Popen-handle to the running process.
+    """
+    return subprocess.Popen(
+        [
+            "stack",
+            "run",
+            "--",
+            "vaultenv",
+            "--no-connect-tls",
+            "--host",
+            os.environ["VAULT_HOST"],
+            "--port",
+            os.environ["VAULT_PORT"],
+            "--secrets-file",
+            str(secrets_file),
+            "/usr/bin/env",
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=None,  # Inherit calling process's stderr
+        text=True,
+    )
+
+
+def check_vaultenv_result(
+    process_handle: subprocess.Popen, secrets_version: int, api_version: int
+) -> None:
+    """
+    Check the return code and output of the Vaultenv process under the given
+    process_handle.
+
+    Emit an appropriate TAP message for the result of the test.
+    """
+
+    description = f"v{secrets_version} secrets/v{api_version} API"
+
+    return_code = process_handle.wait()
+    if return_code != 0:
+        tap.not_ok(f"{description} returned with code {return_code}")
+        return
+
+    expected_env: Set[str]
+    if secrets_version == 1:
+        expected_env = {
+            "TESTING_KEY=testing42",
+            "TESTING_OTHERKEY=testing8",
+            "TESTING2_FOO=val1",
+            "TESTING2_BAR=val2",
+            "TEST_TEST=testing42",
+            "TEST__TEST=testing42",
+            "_TEST__TEST=testing42",
+        }
+    elif secrets_version == 2:
+        expected_env = {
+            "SECRET_TESTING_KEY=testing42",
+            "SECRET_TESTING_OTHERKEY=testing8",
+            "SECRET_TESTING2_FOO=val1",
+            "SECRET_TESTING2_BAR=val2",
+        }
+
+    actual_env = set(line.strip() for line in process_handle.stdout.readlines())
+
+    if not expected_env <= actual_env:
+        missing = ", ".join(expected_env - actual_env)
+        tap.not_ok(f"{description} missing vars {missing}")
+        breakpoint()
+        return
+
+    tap.ok(description)
+
+
+def run_vault_server() -> subprocess.Popen:
+    """
+    Run the Vault dev server and seed it with a known set of secrets.
+    """
+    env = {
+        "VAULT_TOKEN": "integration",
+        "VAULT_HOST": "localhost",
+        "VAULT_PORT": "8200",
+        "VAULT_ADDR": "http://localhost:8200",
+    }
+
+    vault_server = subprocess.Popen(
+        ["vault", "server", "-dev", "-dev-root-token-id=integration"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    sleep(1)  # As in integration_test.sh
+
+    subprocess.run(["vault", "secrets", "disable", "secret"], check=True, env=env)
+    subprocess.run(
+        ["vault", "secrets", "enable", "-path=secret", "-version=1", "kv"],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        ["vault", "kv", "put", "secret/testing", "key=testing42", "otherkey=testing8"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    subprocess.run(
+        ["vault", "kv", "put", "secret/testing2", "foo=val1", "bar=val2"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return vault_server
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/tap.py
+++ b/test/integration/tap.py
@@ -1,0 +1,31 @@
+"""
+Module for producing output according to the Test Anything Protocol.
+The program prove(1) can process this output.
+"""
+
+
+_test_number = 0
+
+
+def plan(n: int) -> None:
+    """Print the number of tests that are to be run."""
+    print(f"1..{n}")
+
+
+def ok(message: str) -> None:
+    """Report that the current test succeeded."""
+    global _test_number
+    _test_number += 1
+    print(f"ok {_test_number} - {message}")
+
+
+def not_ok(message: str) -> None:
+    """Report that the current test failed."""
+    global _test_number
+    _test_number += 1
+    print(f"not ok {_test_number} - {message}")
+
+
+def diagnose(message: str) -> None:
+    """Print debug output."""
+    print(f"# {message}")

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -88,3 +88,5 @@ fi
 
 # Cleanup the vault dev server
 kill %%
+
+PYTHONUNBUFFERED=1 prove --comments integration/retry_tests.py


### PR DESCRIPTION
This PR reworks the internal logic of Vaultenv to remove the use of the `ExceptT`
monad and fix the retrying logic for fetching both the mount information and the
secrets.

It was discovered that the existing retry code had no effect due to the `http`
library throwing IO exceptions, which were not caught by the ExceptT monad
combination we used. Additionally, the retries were not enabled on the first call to
the server for the secret store mount information.

In this PR the relevant functions that use the ExceptT construction are reworked or
replaced to return either `Either VaultError result` or `IO (Either VaultError
result)`, and `Retry.retrying` is used directly to retry when a network-related
`VaultError` is returned.

This PR also alters the handling for HttpExceptions to ensure that the Vault root
token is removed before the exception can be shown.

Fixes #88.
Fixes #90.