### PR TITLE
Fix permission issue on .deb package

### DIFF
--- a/package/build_package.sh
+++ b/package/build_package.sh
@@ -18,24 +18,41 @@ export VERSION=$(stack query locals vaultenv-real version | sed -e "s/^'//" -e "
 # The name of the .deb file to create
 PKGNAME="vaultenv-${VERSION}"
 
-# Recreate the file system layout as it should be on the target machine.
-mkdir -p "$PKGNAME/DEBIAN"
-mkdir -p "$PKGNAME/usr/bin"
-mkdir -p "$PKGNAME/etc/secrets.d"
-
 cd ..
 VAULTENV_NIX_PATH=$($(nix-build --no-link -A full-build-script nix/vaultenv-static.nix) | tail -n1)
 cd -
 
-cp "${VAULTENV_NIX_PATH}/bin/vaultenv" "$PKGNAME/usr/bin/"
-cp "${VAULTENV_NIX_PATH}/bin/vaultenv" "vaultenv-${VERSION}-linux-musl"
+cp --no-preserve=mode,ownership "${VAULTENV_NIX_PATH}/bin/vaultenv" "vaultenv-${VERSION}-linux-musl"
 
-# Write the package metadata file, substituting environment variables in the
-# template file.
-cat deb_control | envsubst > "$PKGNAME/DEBIAN/control"
 
 # Build the Debian package
-dpkg-deb --build "$PKGNAME"
+# We need to use `fakeroot` here to have the package files be correctly owned
+# by `root` without being `root` ourselves.
+fakeroot -- bash <<-EOFAKEROOT
+  # Re-enable safe scripting options since this is a new shell
+  set -euf -o pipefail
+
+  # Ensure created directories are mode 0755 (default is 0775)
+  umask 022
+
+  # Recreate the file system layout as it should be on the target machine.
+  mkdir -p "$PKGNAME/DEBIAN"
+  mkdir -p "$PKGNAME/usr/bin"
+  mkdir -p "$PKGNAME/etc/secrets.d"
+
+  # Write the package metadata file, substituting environment variables in the
+  # template file.
+  cat deb_control | envsubst > "$PKGNAME/DEBIAN/control"
+
+  cp deb_postinst "$PKGNAME/DEBIAN/postinst"
+  chmod 0755 "$PKGNAME/DEBIAN/postinst"
+
+  # Copy the built binary from the Nix store to the target directory
+  cp --no-preserve=mode,ownership "${VAULTENV_NIX_PATH}/bin/vaultenv" "$PKGNAME/usr/bin/"
+  chown root:root "$PKGNAME/usr/bin/vaultenv"
+  chmod 0755 "$PKGNAME/usr/bin/vaultenv"
+  dpkg-deb --build "$PKGNAME"
+EOFAKEROOT
 
 # Clean up temporary files
 rm -fr "$PKGNAME"

--- a/package/build_package.sh
+++ b/package/build_package.sh
@@ -13,7 +13,8 @@ set -euf -o pipefail
 
 # Get the package version from Stack, eliminate the single quotes.
 # Exported, because it is used with envsubst to write the control file.
-export VERSION=$(stack query locals vaultenv-real version | sed -e "s/^'//" -e "s/'$//")
+VERSION=$(stack query locals vaultenv-real version | sed -e "s/^'//" -e "s/'$//")
+export VERSION
 
 # The name of the .deb file to create
 PKGNAME="vaultenv-${VERSION}"

--- a/package/build_package.sh
+++ b/package/build_package.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2091,SC2103
 
 # This script builds a .deb package from the static binary build by Nix.
 #

--- a/package/deb_postinst
+++ b/package/deb_postinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+# If upgrading from 0.13.0 or earlier the permissions on /etc/secrets.d and
+# /usr/bin/vaultenv will be messed up.
+# Fixing this is idempotent so do this here:
+echo "-- Fixing potentially wrong file mode, ownership of /etc/secrets.d, /usr/bin/vaultenv"
+chown root:root /usr/bin/vaultenv /etc/secrets.d
+chmod 0755 /usr/bin/vaultenv /etc/secrets.d
+
+exit 0


### PR DESCRIPTION
We've noticed an issue with the permissions of the file installed from the .deb
package which caused the installed binary and `/etc/secrets.d` to not be owned by
`root` but by the uid of the building user on the build machine.

This PR alters the packaging script to use `fakeroot` to ensure that the built
package includes files owned by `root` instead of some random user, without requiring
building the package as `root`.
It also adds a `postinst` script that will fix the permissions after upgrading from
an affected version of the package.