### PR TITLE
Make vaultenv more friendly for use with Vault Agent

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -361,6 +361,7 @@ requestMountInfo context =
               (cHttpManager context)
         $ setRequestHeader "x-vault-token"
               [SBS.pack (getOptionsValue oVaultToken cliOptions)]
+        $ setRequestHeader "x-vault-request" [SBS.pack "true"]
         $ setRequestPath
               (SBS.pack "/v1/sys/mounts")
         $ setRequestPort
@@ -393,6 +394,7 @@ requestSecret context secretPath =
         = setRequestManager
             (cHttpManager context)
         $ setRequestHeader "x-vault-token" [SBS.pack (getOptionsValue oVaultToken cliOptions)]
+        $ setRequestHeader "x-vault-request" [SBS.pack "true"]
         $ setRequestPath    (SBS.pack secretPath)
         $ setRequestPort    (getOptionsValue oVaultPort cliOptions)
         $ setRequestHost    (SBS.pack (getOptionsValue oVaultHost cliOptions))

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -351,6 +351,19 @@ runCommand options env =
     -- replaces the current process with `command`. It does not return.
     executeFile command searchPath args env'
 
+
+-- | Add Vault authentication token to a request, if set in the options. If
+-- not, the request is returned unmodified.
+addVaultToken :: Options Validated Completed -> Request -> Request
+addVaultToken options request =
+  let
+    optToken = oVaultToken options
+  in
+    case optToken of
+      Just token -> setRequestHeader "x-vault-token" [SBS.pack token] request
+      Nothing -> request
+
+
 -- | Look up what mounts are available and what type they have.
 requestMountInfo :: Context -> IO (Either VaultError MountInfo)
 requestMountInfo context =
@@ -359,9 +372,8 @@ requestMountInfo context =
     request
         = setRequestManager
               (cHttpManager context)
-        $ setRequestHeader "x-vault-token"
-              [SBS.pack (getOptionsValue oVaultToken cliOptions)]
-        $ setRequestHeader "x-vault-request" [SBS.pack "true"]
+        $ addVaultToken cliOptions
+        $ setRequestHeader "x-vault-request" ["true"]
         $ setRequestPath
               (SBS.pack "/v1/sys/mounts")
         $ setRequestPort
@@ -393,8 +405,8 @@ requestSecret context secretPath =
     request
         = setRequestManager
             (cHttpManager context)
-        $ setRequestHeader "x-vault-token" [SBS.pack (getOptionsValue oVaultToken cliOptions)]
-        $ setRequestHeader "x-vault-request" [SBS.pack "true"]
+        $ addVaultToken     cliOptions
+        $ setRequestHeader "x-vault-request" ["true"]
         $ setRequestPath    (SBS.pack secretPath)
         $ setRequestPort    (getOptionsValue oVaultPort cliOptions)
         $ setRequestHost    (SBS.pack (getOptionsValue oVaultHost cliOptions))
@@ -443,6 +455,7 @@ parseResponse secretPath response =
     statusCode = getResponseStatusCode response
   in case statusCode of
     200 -> parseSuccessResponse responseBody
+    400 -> Left $ BadRequest responseBody
     403 -> Left Forbidden
     404 -> Left $ SecretNotFound secretPath
     500 -> Left $ ServerError responseBody

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -258,12 +258,8 @@ mergeOptions opts1 opts2 = let
 isOptionsComplete :: Options Validated UnCompleted
                   -> Either [OptionsError] (Options Validated Completed)
 isOptionsComplete opts =
-      let errors = concat
-            [
-              [UnspecifiedValue "Token"       | isNothing (oVaultToken opts)]
-            , [UnspecifiedValue "Command"     | isNothing (oCmd opts)]
-            , [UnspecifiedValue "Secret file" | isNothing (oSecretFile opts)]
-            ]
+      let errors = [UnspecifiedValue "Command" | isNothing (oCmd opts)]
+            ++ [UnspecifiedValue "Secret file" | isNothing (oSecretFile opts)]
       in  if not (null errors)
           then Left errors
           else Right (castOptions opts)


### PR DESCRIPTION
Vault Agent is a kind of local Vault proxy that can take care of authentication and caching, but it's better described by [its own documentation](https://www.vaultproject.io/docs/agent).

This PR makes Vaultenv easier to use with Vault agent, with two changes:

- The `Token` parameter is now optional, as it is not required when the Vault Agent provides auto authentication. If the parameter is not set, the relevant header is not added to the request. If the token turned out to be required after all, the Vault server will respond with a `BadRequest` informing you of that fact so it still fails fast.
- The `x-vault-request: true` header is added to every request. If Vault's SSRF protection is enabled, this header is required for requests to go through. Otherwise, it is silently ignored, just like any other optional header.