### PR TITLE
Fix `build_package.sh`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,6 @@
       stack
       vault
       cachix
-
       niv
     ];
   }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,5 +10,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/65f4c39a40e6ed4343dd94017c3ed81f416cd3b4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "static-haskell-nix": {
+        "branch": "master",
+        "description": "easily build most Haskell programs into fully static Linux executables",
+        "homepage": "",
+        "owner": "nh2",
+        "repo": "static-haskell-nix",
+        "rev": "ff7715e0e13fb3f615e64a8d8c2e43faa4429b0f",
+        "sha256": "17ir87i7sah9nixvh25qhzh19bqv3vgnfg4nfy4wv631q4gfj7fb",
+        "type": "tarball",
+        "url": "https://github.com/nh2/static-haskell-nix/archive/ff7715e0e13fb3f615e64a8d8c2e43faa4429b0f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -11,7 +11,7 @@ in
         # bundled with all the dependencies listed in `haskell-dependencies.nix`.
         # This allows us to have stack use the dependencies from nixpkgs,
         # instead of fetching them itself.
-        ghc = nixpkgs.haskellPackages.ghcWithPackages getDependencies;
+        ghc = nixpkgs.haskell.packages.ghc865.ghcWithPackages getDependencies;
         buildInputs = with nixpkgs; [
           glibcLocales
         ];

--- a/nix/vaultenv-static.nix
+++ b/nix/vaultenv-static.nix
@@ -1,0 +1,90 @@
+# This is the default build script taken from static-haskell-nix.
+# We've adjusted some things and removed some instructions that
+# we didn't have a usecase for.
+#
+# Run using:
+#
+#     $(nix-build --no-link -A full-build-script nix/vaultenv-static.nix)
+#
+# The invocation above will build a buildscript and then run it.
+# (The output of `nix-build --no-link -A full-build-script` is a
+# path to the build script. The `$()` invokes the script.)
+#
+# That will:
+#
+#   - Fetch a stackage snapshot and run stack2nix on it. This
+#     yields a bunch of nix derivations of the entire snapshot.
+#     Some of these will be used in the actual build for the
+#     vaultenv package.
+#   - Download or build a GHC compiled with musl and integer-simple.
+#   - Build vaultenv with integer-simple and link everything
+#     statically. Dependencies are taken from stack.yaml in this
+#     repository.
+#
+# The final output of the invocation above will print a Nix store path
+# like `/nix/store/ak6qm8qmb66zwri7y16sqina1pvn0gmz-vaultenv-real-0.10.0`
+# which will contain a fully static vaultenv binary in the `bin/` subdir.
+{
+  stack2nix-output-path ? "custom-stack2nix-output.nix",
+}:
+let
+  # Field from the hpack/cabal file. We append `-real` to work around
+  # vaultenv also being included in `nixpgks`, which leads to conflicts.
+  cabal-package-name = "vaultenv-real";
+
+  # This has to match the compiler used in the Stackage snapshot.
+  # Update this when the Stackage snapshot changes the version of
+  # GHC it uses.
+  compiler = "ghc865";
+
+  # Pin versions of static-haskell-nix and nixpkgs.
+  sources = import ./sources.nix;
+  static-haskell-nix = sources.static-haskell-nix;
+  pkgs = import ./nixpkgs-pinned.nix {};
+
+  # Generate a stack2nix script which will download a Stackage + Hackage
+  # snapshot and convert it to Nix derivations for use in our final build
+  # script.
+  stack2nix-script = import "${static-haskell-nix}/static-stack2nix-builder/stack2nix-script.nix" {
+    inherit pkgs;
+    stack-project-dir = toString ../.;
+    # Also pin the Hackage snapshot to a certain time for extra-deps without
+    # hashes or revisions. Vaultenv doesn't have any, but it's there if it
+    # ever turns out we need it.
+    hackageSnapshot = "2019-10-08T00:00:00Z";
+    stack-yaml = "stack-static-build.yaml";
+  };
+
+  # `full-build-script` will eventually build the `static_package` attribute of
+  # this set. Note `nix-build -A static-package` in `full-build-script` and
+  # `static-package` in the `in` of this module.
+  #
+  # The `static_package` attribute boils down to `haskellPackages.vaultenv-real`
+  # with modifications to get static builds to work. `haskellPackages` is
+  # Nixpkgs' infrastructure for Haskell applications and libraries.
+  #
+  # Take a look at `survey/default.nix` in the `static-haskell-nix` repository
+  # if you want to know what patches have been applied to `haskellPackages`.
+  static-stack2nix-builder = import "${static-haskell-nix}/static-stack2nix-builder/default.nix" {
+    normalPkgs = pkgs;
+    integer-simple = true;
+    cabalPackageName = cabal-package-name;
+    inherit compiler stack2nix-output-path;
+  };
+
+  # This build script invokes `nix-build` on this same file using nix build
+  # from a pinned version of nixpkgs. It will build the `static_package`
+  # attribute that we define in the set below.
+  full-build-script = pkgs.writeScript "stack2nix-and-build-script.sh" ''
+    #!/usr/bin/env bash
+    set -eu -o pipefail
+    STACK2NIX_OUTPUT_PATH=$(${stack2nix-script})
+    export NIX_PATH=nixpkgs=${pkgs.path}
+    ${pkgs.nix}/bin/nix-build --no-link -A static-package --argstr stack2nix-output-path "$STACK2NIX_OUTPUT_PATH" nix/vaultenv-static.nix "$@"
+  '';
+
+in
+  {
+    inherit full-build-script;
+    static-package = static-stack2nix-builder.static_package;
+  }

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 # Changed the name here because nixpkgs also includes a vaultenv and we haven't
 # figured out how to mask that when we build vaultenv with nix itself.
 name: vaultenv-real
-version: 0.13.1
+version: 0.13.2
 synopsis: Runs processes with secrets from HashiCorp Vault
 license: BSD3
 github: channable/vaultenv

--- a/stack-static-build.yaml
+++ b/stack-static-build.yaml
@@ -1,0 +1,6 @@
+# Also take care to update the compiler in default.nix to the
+# compiler used in this Stackage snapshot.
+resolver: lts-14.7
+
+packages:
+  - "."

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,8 @@
 # Also take care to update the compiler in default.nix to the
 # compiler used in this Stackage snapshot.
-resolver: ghc-8.8.4
+# This value has a companion file named `stack-static-build.yaml`, used for static builds.
+# When updating this resolver, update that file as well.
+resolver: ghc-8.6.5
 
 packages:
   - "."

--- a/vaultenv.nix
+++ b/vaultenv.nix
@@ -9,7 +9,7 @@ let
 in
 mkDerivation {
   pname = "vaultenv";
-  version = "0.13.1";
+  version = "0.13.2";
 
   src =
     let


### PR DESCRIPTION
Fixes `build_package.sh`, that broke after https://github.com/channable/vaultenv/pull/98

This PR:
- Reverts the GHC version back to 8.6.5
- Uses the correct GHC version when using stack
- Allows building of static packages again, by using a separate `.yaml` file.