### PR TITLE
Ignore non-string responses in the data object from Vault

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -117,7 +117,7 @@ instance FromJSON VaultData where
         flip (Aeson.withObject "nested") nested $ \obj' -> do
           keyValuePairs <- obj' .: "data"
           VaultData <$> Aeson.parseJSON keyValuePairs
-    in Aeson.withObject "object" $ \obj -> parseV2 obj <|> parseV1 obj
+    in Aeson.withObject "VaultData" $ \obj -> parseV2 obj <|> parseV1 obj
 
 -- Parses a very mixed type of response that Vault gives back when you
 -- request /sys/mounts. It has a garbage format. We primarily care about


### PR DESCRIPTION
Some secret providers may return non-string values in their data blob (for example, the AWS provider sometimes returns `{"data":{"security_token":null}}` as part of its response, which doesn't parse because we're expecting `data` to contain just string values. This happens even if you're not actually trying to use those response values.

This change parses it as an Aeson.Object instead, and then removes all values that aren't strings.

My Haskell is a bit rusty, so this may not have been the best way to implement things. E.g. I'm not exactly sure what the tradeoff is on using `HashMap` instead of `Map`, but since `Aeson.Object` is a `HashMap` it seemed to make sense to keep it that way instead of converting it back to a `Map`.

Another option for this would be to try to convert non-string values to strings with `show` or something, I'm not entirely sure which approach is better.