### PR TITLE
Use nix derivation in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: true
-language: generic
+language: nix
 
 notifications:
   email: false
@@ -17,18 +17,9 @@ env:
   global:
     - GITHUB_RELEASE_VERSION=1.2.4
 
-before_install:
-  - mkdir -p ~/.local/bin
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        travis_retry curl -sSL https://www.stackage.org/stack/osx-x86_64   | tar xz --strip-components=1 --include  '*/stack' -C ~/.local/bin
-    else
-        travis_retry curl -sSL https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-    fi
-
 install:
-  - stack setup --no-terminal
-  - stack build --only-dependencies --test --copy-bins
+  - nix run -c stack setup --no-terminal
+  - nix run -c stack build --only-dependencies --test
 
 script:
-  - stack test --copy-bins
+  - nix run -c stack test


### PR DESCRIPTION
Currently CI seems to be failing due to the stack project not working without Nix set up. This pulls in Nix in CI and uses nix to run the build and test commands. Since Nix will handle downloading Stack, we no longer need to install it manually either.

I removed `--copy-bins` as well, since it doesn't seem to be necessary and seems to error for me locally when run using Nix.