### PR TITLE
Limit parallelism, enabling more connection reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,17 @@ of `tutorial.sh`.
 ## Usage
 
 ```
-vaultenv 0.11.0 - run programs with secrets from HashiCorp Vault
+vaultenv 0.13.2 - run programs with secrets from HashiCorp Vault
 
 Usage: vaultenv [--version] [--host HOST] [--port PORT] [--addr ADDR]
                 [--token TOKEN] [--secrets-file FILENAME] [CMD] [ARGS...]
-                ([--no-connect-tls] | [--connect-tls]) ([--no-validate-certs] |
-                [--validate-certs]) ([--no-inherit-env] | [--inherit-env])
+                [--no-connect-tls | --connect-tls]
+                [--no-validate-certs | --validate-certs]
+                [--no-inherit-env | --inherit-env]
                 [--inherit-env-blacklist COMMA_SEPARATED_NAMES]
                 [--retry-base-delay-milliseconds MILLISECONDS]
                 [--retry-attempts NUM] [--log-level error | info] [--use-path]
+                [--max-concurrent-requests NUM]
 
 Available options:
   -h,--help                Show this help text
@@ -161,6 +163,11 @@ Available options:
   --use-path               Use PATH for finding the executable that vaultenv
                            should call. Default: don't search PATH. Also
                            configurable via VAULTENV_USE_PATH.
+  --max-concurrent-requests NUM
+                           Maximum number of concurrent requests to vault.
+                           Defaults to 8. Pass 0 to disable the limit. Also
+                           configurable through
+                           VAULTENV_MAX_CONCURRENT_REQUESTS.
 ```
 
 ## Configuration
@@ -288,6 +295,7 @@ VAULTENV_RETRY_BASE_DELAY:      40
 VAULTENV_RETRY_ATTEMPTS:        9
 VAULTENV_LOG_LEVEL:             Error
 VAULTENV_USE_PATH:              True
+VAULTENV_MAX_CONCURRENT_REQUESTS: 8
 ```
 In cases where no default nor any value is specified, which is possible for `Token`, `Secret file` and
 `Command`, Vaultenv will give an error that it requires these values to operate.
@@ -319,6 +327,11 @@ due to the `http://` scheme, and a port of `42`.
 Other errors than the mismatch address error that can happen during parsing are:
 - A non-numeric port in the address, like `http://localhost:my_port`
 - A non-supported scheme in the address, like `ftp://example.com:42`
+
+By default, `vaultenv` will open at most 8 concurrent HTTP connections to the vault server.
+This limit can be changed using the `VAULTENV_MAX_CONCURRENT_REQUESTS` setting, and it can
+be disabled by choosing the limit `0`.
+
 ## Allowed characters in environment variables
 
 We disallow the following in any path to keep the parser and format simple and

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Applicative    ((<|>))
-import Control.Exception      (catch)
+import Control.Concurrent.QSem (newQSem, waitQSem, signalQSem)
+import Control.Exception      (bracket_, catch)
 import Control.Monad          (forM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson             (FromJSON, (.:))
@@ -14,7 +15,7 @@ import Data.HashMap.Strict    (HashMap, lookupDefault, mapMaybe)
 import Data.List              (nubBy)
 import Data.Text              (Text, pack, unpack)
 import Network.Connection     (TLSSettings(..))
-import Network.HTTP.Client    (defaultManagerSettings)
+import Network.HTTP.Client    (defaultManagerSettings, ManagerSettings (managerConnCount))
 import Network.HTTP.Conduit   (Manager, newManager, mkManagerSettings)
 import Network.HTTP.Simple    (HttpException(..), Request, Response,
                                defaultRequest, setRequestHeader, setRequestPort,
@@ -263,9 +264,16 @@ main = do
 -- for HTTPS connections. If TLS is wanted, we also check if the
 -- user specified an option to disable the certificate check.
 getHttpManager :: Options Validated Completed -> IO Manager
-getHttpManager opts = newManager managerSettings
+getHttpManager opts = newManager $ applyConfig basicManagerSettings
   where
-    managerSettings = if getOptionsValue oConnectTls opts
+    maxConnections = getOptionsValue oMaxConcurrentRequests opts
+    applyConfig settings = settings
+      -- Allow the manager to keep as many connections live as were requested.
+      -- Unless we use the unlimited flag, in that case, use the default value.
+      { managerConnCount = if maxConnections > 0 then maxConnections else managerConnCount settings
+      }
+
+    basicManagerSettings = if getOptionsValue oConnectTls opts
                       then mkManagerSettings tlsSettings Nothing
                       else defaultManagerSettings
     tlsSettings = TLSSettingsSimple
@@ -426,8 +434,18 @@ requestSecret context secretPath =
 -- order to avoid unnecessary round trips and DNS requests.
 requestSecrets :: Context -> MountInfo -> [Secret] -> IO (Either VaultError [EnvVar])
 requestSecrets context mountInfo secrets = do
-  let secretPaths = Foldable.foldMap (\x -> Map.singleton x x) $ fmap (secretRequestPath mountInfo) secrets
-  secretData <- liftIO (Async.mapConcurrently (requestSecret context) secretPaths)
+  let
+    secretPaths = Foldable.foldMap (\x -> Map.singleton x x) $ fmap (secretRequestPath mountInfo) secrets
+    concurrentRequests = getOptionsValue oMaxConcurrentRequests (cCliOptions context)
+
+  -- Limit the number of concurrent requests with a semaphore
+  requestSemaphore <- newQSem concurrentRequests
+  let
+    withSemaphore
+      | concurrentRequests == 0 = id
+      | otherwise = bracket_ (waitQSem requestSemaphore) (signalQSem requestSemaphore)
+
+  secretData <- liftIO (Async.mapConcurrently (withSemaphore . requestSecret context) secretPaths)
   pure $ sequence secretData >>= lookupSecrets mountInfo secrets
 
 -- | Look for the requested keys in the secret data that has been previously fetched.

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -68,6 +68,7 @@ data Options validated completed = Options
   , oRetryAttempts   :: Maybe Int
   , oLogLevel        :: Maybe LogLevel
   , oUsePath         :: Maybe Bool
+  , oMaxConcurrentRequests :: Maybe Int
   } deriving (Eq)
 
 -- | Phantom type that indicates that an option is
@@ -105,9 +106,14 @@ defaultOptions = Options
   , oRetryAttempts  = Just 9
   , oLogLevel       = Just Error
   , oUsePath        = Just True
+
+  -- Number of concurrent requests to send to the vault server.
+  -- The default has been chosen by doubling the limit in combination with a suitably large
+  -- secrets file until the gain in performance was insignificant.
+  , oMaxConcurrentRequests = Just 8
 }
 
--- | Casts one options structure into antoher, use only when certain that
+-- | Casts one options structure into another, use only when certain that
 -- the validated and completed options can be given to a options file.
 castOptions :: Options a b -> Options c d
 castOptions opts = Options
@@ -126,25 +132,27 @@ castOptions opts = Options
   , oRetryAttempts  = oRetryAttempts opts
   , oLogLevel       = oLogLevel opts
   , oUsePath        = oUsePath opts
+  , oMaxConcurrentRequests = oMaxConcurrentRequests opts
   }
 
 instance Show (Options valid complete) where
   show opts = intercalate "\n"
-    [ "Host:           " ++ showSpecifiedString (oVaultHost opts)
-    , "Port:           " ++ showSpecified (oVaultPort opts)
-    , "Addr:           " ++ showSpecified (oVaultAddr opts)
-    , "Token:          " ++ maybe "Unspecified" (const "*****") (oVaultToken opts)
-    , "Secret file:    " ++ showSpecifiedString (oSecretFile opts)
-    , "Command:        " ++ showSpecifiedString (oCmd opts)
-    , "Arguments:      " ++ showSpecified (oArgs opts)
-    , "Use TLS:        " ++ showSpecified (oConnectTls opts)
-    , "Validate certs: " ++ showSpecified (oValidateCerts opts)
-    , "Inherit env:    " ++ showSpecified (oInheritEnv opts)
+    [ "Host:                  " ++ showSpecifiedString (oVaultHost opts)
+    , "Port:                  " ++ showSpecified (oVaultPort opts)
+    , "Addr:                  " ++ showSpecified (oVaultAddr opts)
+    , "Token:                 " ++ maybe "Unspecified" (const "*****") (oVaultToken opts)
+    , "Secret file:           " ++ showSpecifiedString (oSecretFile opts)
+    , "Command:               " ++ showSpecifiedString (oCmd opts)
+    , "Arguments:             " ++ showSpecified (oArgs opts)
+    , "Use TLS:               " ++ showSpecified (oConnectTls opts)
+    , "Validate certs:        " ++ showSpecified (oValidateCerts opts)
+    , "Inherit env:           " ++ showSpecified (oInheritEnv opts)
     , "Inherit env blacklist: " ++ showSpecified (oInheritEnvBlacklist opts)
-    , "Base delay:     " ++ showSpecified (unMilliSeconds <$> oRetryBaseDelay opts)
-    , "Retry attempts: " ++ showSpecified (oRetryAttempts opts)
-    , "Log-level:      " ++ showSpecified (oLogLevel opts)
-    , "Use PATH:       " ++ showSpecified (oUsePath opts)
+    , "Base delay:            " ++ showSpecified (unMilliSeconds <$> oRetryBaseDelay opts)
+    , "Retry attempts:        " ++ showSpecified (oRetryAttempts opts)
+    , "Log-level:             " ++ showSpecified (oLogLevel opts)
+    , "Use PATH:              " ++ showSpecified (oUsePath opts)
+    , "Concurrent requests:   " ++ showSpecified (oMaxConcurrentRequests opts)
     ] where
       showSpecified :: Show a => Maybe a -> String
       showSpecified (Just x) = show x
@@ -247,6 +255,7 @@ mergeOptions opts1 opts2 = let
   , oRetryAttempts  = combine oRetryAttempts
   , oLogLevel       = combine oLogLevel
   , oUsePath        = combine oUsePath
+  , oMaxConcurrentRequests = combine oMaxConcurrentRequests
   }
 
 
@@ -369,6 +378,7 @@ parseEnvOptions envVars
   , oRetryAttempts  = lookupEnvInt      "VAULTENV_RETRY_ATTEMPTS"
   , oLogLevel       = lookupEnvLogLevel "VAULTENV_LOG_LEVEL"
   , oUsePath        = lookupEnvFlag     "VAULTENV_USE_PATH"
+  , oMaxConcurrentRequests = lookupEnvInt "VAULTENV_MAX_CONCURRENT_REQUESTS"
   }
   where
     -- | Throws an error for an invalid key
@@ -495,6 +505,7 @@ optionsParser = Options
     <*> retryAttempts
     <*> logLevel
     <*> usePath
+    <*> maxConcurrentRequests
   where
     maybeStr = Just <$> str
     maybeStrOption = option maybeStr
@@ -613,6 +624,14 @@ optionsParser = Options
       $  long "use-path"
       <> help ("Use PATH for finding the executable that vaultenv should call. Default: " ++
               "don't search PATH. Also configurable via VAULTENV_USE_PATH.")
+    maxConcurrentRequests
+      =  option (Just <$> auto)
+      $  long "max-concurrent-requests"
+      <> metavar "NUM"
+      <> value Nothing
+      <> help ("Maximum number of concurrent requests to vault. Defaults to 8. " ++
+               "Pass 0 to disable the limit. " ++
+               "Also configurable through VAULTENV_MAX_CONCURRENT_REQUESTS.")
 
 -- | Split a list of elements on the given separator, returning sublists without this
 -- separator item.


### PR DESCRIPTION
When there are a lot of secrets to be fetched, imposing a limit makes it
possible to reuse more connections to the vault server. This reduces the
load on the vault server because expensive TLS handshakes can be
avoided.

Closes https://github.com/channable/vaultenv/issues/106.