### PR TITLE
Include unit when logging base delay option

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -148,7 +148,9 @@ instance Show (Options valid complete) where
     , "Validate certs:        " ++ showSpecified (oValidateCerts opts)
     , "Inherit env:           " ++ showSpecified (oInheritEnv opts)
     , "Inherit env blacklist: " ++ showSpecified (oInheritEnvBlacklist opts)
-    , "Base delay:            " ++ showSpecified (unMilliSeconds <$> oRetryBaseDelay opts)
+    , "Base delay:            " ++ case oRetryBaseDelay opts of
+        Just (MilliSeconds ms) -> (show ms) ++ " ms"
+        Nothing -> "Unspecified"
     , "Retry attempts:        " ++ showSpecified (oRetryAttempts opts)
     , "Log-level:             " ++ showSpecified (oLogLevel opts)
     , "Use PATH:              " ++ showSpecified (oUsePath opts)


### PR DESCRIPTION
Logging just "Base delay: 40" is not very helpful. 40 what? Seconds? Milliseconds? Martian days? Clarify that by including the unit.

Before:
```console
$ vaultenv --log-level info --secrets-file secrets env
...
Base delay:            40
...
```

After:
```console
$ vaultenv --log-level info --secrets-file secrets env
...
Base delay:            40 ms
...
```