### PR TITLE
Add support for Kubernetes authentication

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -296,12 +296,12 @@ getHttpManager opts = newManager $ applyConfig basicManagerSettings
 -- Signals failure through a value of type VaultError.
 vaultEnv :: Context -> IO (Either VaultError [EnvVar])
 vaultEnv context =
-  doWithRetries retryPolicy getMountInfo >>= \case
-    Left vaultError -> pure $ Left vaultError
-    Right mountInfo ->
-      readSecretsFile secretFile >>= \case
-        Left sfError -> pure $ Left $ SecretFileError sfError
-        Right secrets ->
+  readSecretsFile secretFile >>= \case
+    Left sfError -> pure $ Left $ SecretFileError sfError
+    Right secrets ->
+      doWithRetries retryPolicy getMountInfo >>= \case
+        Left vaultError -> pure $ Left vaultError
+        Right mountInfo ->
           requestSecrets context mountInfo secrets >>= \case
             Left vaultError -> pure $ Left vaultError
             Right secretEnv -> pure $ checkNoDuplicates (buildEnv secretEnv)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,7 +31,7 @@ import qualified Control.Retry              as Retry
 import qualified Data.Aeson                 as Aeson
 import qualified Data.ByteString            as ByteString
 import qualified Data.ByteString.Char8      as SBS
-import qualified Data.ByteString.Lazy       as LBS hiding (unpack)
+import qualified Data.ByteString.Lazy       as LBS hiding (unpack, putStrLn)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Foldable              as Foldable
 import qualified Data.HashMap.Strict        as HashMap
@@ -454,9 +454,11 @@ requestKubernetesVaultToken context role = do
           $ unauthenticatedVaultRequest context "/v1/auth/kubernetes/login"
       in do
         response <- httpLBS request
-        case Aeson.eitherDecode' (getResponseBody response) of
-          Left err    -> pure $ Left $ BadJSONResp err
-          Right token -> pure $ Right token
+        case getResponseStatusCode response of
+          200 -> case Aeson.eitherDecode' (getResponseBody response) of
+            Left err    -> pure $ Left $ BadJSONResp err
+            Right token -> pure $ Right token
+          _notOk -> pure $ Left $ ServerError $ getResponseBody response
 
 -- | Look up what mounts are available and what type they have.
 requestMountInfo :: Context -> IO (Either VaultError MountInfo)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -326,8 +326,8 @@ vaultEnv originalContext =
         -- enabled, then we do that here and then fill out the token.
         AuthVaultToken _ -> pure $ Right context
         AuthNone -> pure $ Right context
-        AuthKubernetes ->
-          catch (requestKubernetesVaultToken context) httpErrorHandler >>= \case
+        AuthKubernetes role ->
+          catch (requestKubernetesVaultToken context role) httpErrorHandler >>= \case
             Left vaultError -> pure $ Left vaultError
             Right token -> pure $
               Right context
@@ -395,7 +395,7 @@ runCommand options env =
 addVaultToken :: Options Validated Completed -> Request -> Request
 addVaultToken options request = case oAuthMethod options of
   AuthVaultToken token -> setRequestHeader "x-vault-token" [Text.encodeUtf8 token] request
-  AuthKubernetes -> error "Auth method should have been resolved to token by now."
+  AuthKubernetes _ -> error "Kubernetes auth method should have been resolved to token by now."
   AuthNone -> request
 
 unauthenticatedVaultRequest :: Context -> String -> Request
@@ -428,8 +428,8 @@ readKubernetesJwt =
       ]
 
 -- | Authenticate using Kubernetes auth, see https://www.vaultproject.io/docs/auth/kubernetes.
-requestKubernetesVaultToken :: Context -> IO (Either VaultError Text)
-requestKubernetesVaultToken context = do
+requestKubernetesVaultToken :: Context -> Text -> IO (Either VaultError Text)
+requestKubernetesVaultToken context role = do
   jwtResult <- readKubernetesJwt
   case jwtResult of
     Left err -> pure $ Left err
@@ -437,7 +437,7 @@ requestKubernetesVaultToken context = do
       let
         bodyJson = Aeson.Object $ HashMap.fromList
           [ ("jwt", Aeson.String jwt)
-          , ("role", Aeson.String "TODO ROLE")
+          , ("role", Aeson.String role)
           ]
         request =
           setRequestBodyJSON bodyJson

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@
 
 import Control.Applicative    ((<|>))
 import Control.Concurrent.QSem (newQSem, waitQSem, signalQSem)
-import Control.Exception      (bracket_, catch)
+import Control.Exception      (Handler (..), bracket_, catch, catches)
 import Control.Monad          (forM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson             (FromJSON, (.:))
@@ -18,7 +18,8 @@ import Network.Connection     (TLSSettings(..))
 import Network.HTTP.Client    (defaultManagerSettings, ManagerSettings (managerConnCount))
 import Network.HTTP.Conduit   (Manager, newManager, mkManagerSettings)
 import Network.HTTP.Simple    (HttpException(..), Request, Response,
-                               defaultRequest, setRequestHeader, setRequestPort,
+                               defaultRequest, setRequestBodyJSON, setRequestHeader,
+                               setRequestMethod, setRequestPort,
                                setRequestPath, setRequestHost, setRequestManager,
                                setRequestSecure, httpLBS, getResponseBody,
                                getResponseStatusCode)
@@ -28,12 +29,15 @@ import System.Posix.Process   (executeFile)
 import qualified Control.Concurrent.Async   as Async
 import qualified Control.Retry              as Retry
 import qualified Data.Aeson                 as Aeson
+import qualified Data.ByteString            as ByteString
 import qualified Data.ByteString.Char8      as SBS
 import qualified Data.ByteString.Lazy       as LBS hiding (unpack)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Foldable              as Foldable
+import qualified Data.HashMap.Strict        as HashMap
 import qualified Data.Map                   as Map
-import qualified Data.HashMap.Strict        as HM
+import qualified Data.Text.Encoding         as Text
+import qualified Data.Text.Encoding.Error   as Text
 import qualified System.Exit                as Exit
 
 import Config (AuthMethod (..), Options(..), parseOptions, unMilliSeconds,
@@ -173,6 +177,8 @@ data VaultError
   | InvalidUrl String
   | DuplicateVar String
   | Unspecified Int LBS.ByteString
+  | KubernetesJwtInvalidUtf8
+  | KubernetesJwtFailedRead
   deriving Show
 
 -- | "Handle" a HttpException by wrapping it in a Left VaultError.
@@ -222,6 +228,8 @@ doWithRetries retryPolicy = Retry.retrying retryPolicy isRetryableFailure
       Forbidden -> False
       InvalidUrl _ -> False
       SecretNotFound _ -> False
+      KubernetesJwtInvalidUtf8 -> False
+      KubernetesJwtFailedRead -> False
 
       -- Errors that cannot occur at this point, but we list for
       -- exhaustiveness checking.
@@ -295,23 +303,43 @@ getHttpManager opts = newManager $ applyConfig basicManagerSettings
 --
 -- Signals failure through a value of type VaultError.
 vaultEnv :: Context -> IO (Either VaultError [EnvVar])
-vaultEnv context =
+vaultEnv originalContext =
   readSecretsFile secretFile >>= \case
     Left sfError -> pure $ Left $ SecretFileError sfError
     Right secrets ->
-      doWithRetries retryPolicy getMountInfo >>= \case
+      doWithRetries retryPolicy (authenticate originalContext) >>= \case
         Left vaultError -> pure $ Left vaultError
-        Right mountInfo ->
-          requestSecrets context mountInfo secrets >>= \case
+        Right authenticatedContext ->
+          doWithRetries retryPolicy (getMountInfo authenticatedContext) >>= \case
             Left vaultError -> pure $ Left vaultError
-            Right secretEnv -> pure $ checkNoDuplicates (buildEnv secretEnv)
+            Right mountInfo ->
+              requestSecrets authenticatedContext mountInfo secrets >>= \case
+                Left vaultError -> pure $ Left vaultError
+                Right secretEnv -> pure $ checkNoDuplicates (buildEnv secretEnv)
     where
-      retryPolicy = vaultRetryPolicy (cCliOptions context)
+      retryPolicy = vaultRetryPolicy (cCliOptions originalContext)
 
-      getMountInfo :: Retry.RetryStatus -> IO (Either VaultError MountInfo)
-      getMountInfo _retryStatus = catch (requestMountInfo context) httpErrorHandler
+      authenticate :: Context -> Retry.RetryStatus -> IO (Either VaultError Context)
+      authenticate context _retryStatus = case oAuthMethod (cCliOptions context) of
+        -- If we have a token already, or if we should not authenticate at all,
+        -- then there is nothing to be done here. But if Kubernetes auth is
+        -- enabled, then we do that here and then fill out the token.
+        AuthVaultToken _ -> pure $ Right context
+        AuthNone -> pure $ Right context
+        AuthKubernetes ->
+          catch (requestKubernetesVaultToken context) httpErrorHandler >>= \case
+            Left vaultError -> pure $ Left vaultError
+            Right token -> pure $
+              Right context
+                { cCliOptions = (cCliOptions context)
+                  { oAuthMethod = AuthVaultToken token
+                  }
+                }
 
-      secretFile = getOptionsValue oSecretFile (cCliOptions context)
+      getMountInfo :: Context -> Retry.RetryStatus -> IO (Either VaultError MountInfo)
+      getMountInfo context _retryStatus = catch (requestMountInfo context) httpErrorHandler
+
+      secretFile = getOptionsValue oSecretFile (cCliOptions originalContext)
 
       -- | Check that the given list of EnvVars contains no duplicate
       -- variables, return a DuplicateVar error if it does.
@@ -340,12 +368,12 @@ vaultEnv context =
       -- called and apply the blacklist.
       buildEnv :: [EnvVar] -> [EnvVar]
       buildEnv secretsEnv =
-        if getOptionsValue oInheritEnv . cCliOptions $ context
-        then removeBlacklistedVars $ secretsEnv ++ cLocalEnvVars context
+        if getOptionsValue oInheritEnv . cCliOptions $ originalContext
+        then removeBlacklistedVars $ secretsEnv ++ cLocalEnvVars originalContext
         else secretsEnv
 
         where
-          inheritEnvBlacklist = getOptionsValue oInheritEnvBlacklist . cCliOptions $ context
+          inheritEnvBlacklist = getOptionsValue oInheritEnvBlacklist . cCliOptions $ originalContext
           removeBlacklistedVars = filter (not . flip elem inheritEnvBlacklist . fst)
 
 
@@ -366,30 +394,65 @@ runCommand options env =
 -- not, the request is returned unmodified.
 addVaultToken :: Options Validated Completed -> Request -> Request
 addVaultToken options request = case oAuthMethod options of
-  AuthVaultToken token -> setRequestHeader "x-vault-token" [SBS.pack token] request
+  AuthVaultToken token -> setRequestHeader "x-vault-token" [Text.encodeUtf8 token] request
   AuthKubernetes -> error "Auth method should have been resolved to token by now."
   AuthNone -> request
 
+unauthenticatedVaultRequest :: Context -> String -> Request
+unauthenticatedVaultRequest context path =
+  let
+    cliOptions = cCliOptions context
+  in
+    setRequestManager (cHttpManager context)
+    $ setRequestHeader "x-vault-request" ["true"]
+    $ setRequestPath (SBS.pack path)
+    $ setRequestPort (getOptionsValue oVaultPort cliOptions)
+    $ setRequestHost (SBS.pack (getOptionsValue oVaultHost cliOptions))
+    $ setRequestSecure (getOptionsValue  oConnectTls cliOptions)
+    $ defaultRequest
+
+kubernetesJwtPath :: FilePath
+kubernetesJwtPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+-- | Read the contents of `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+readKubernetesJwt :: IO (Either VaultError Text)
+readKubernetesJwt =
+  let
+    readJwtFile = do
+      contentsUtf8 <- ByteString.readFile kubernetesJwtPath
+      pure $ Right $ Text.decodeUtf8With Text.strictDecode contentsUtf8
+  in
+    readJwtFile `catches`
+      [ Handler $ \(_ :: Text.UnicodeException) -> pure $ Left KubernetesJwtInvalidUtf8
+      , Handler $ \(_ :: IOError) -> pure $ Left KubernetesJwtFailedRead
+      ]
+
+-- | Authenticate using Kubernetes auth, see https://www.vaultproject.io/docs/auth/kubernetes.
+requestKubernetesVaultToken :: Context -> IO (Either VaultError Text)
+requestKubernetesVaultToken context = do
+  jwtResult <- readKubernetesJwt
+  case jwtResult of
+    Left err -> pure $ Left err
+    Right jwt ->
+      let
+        bodyJson = Aeson.Object $ HashMap.fromList
+          [ ("jwt", Aeson.String jwt)
+          , ("role", Aeson.String "TODO ROLE")
+          ]
+        request =
+          setRequestBodyJSON bodyJson
+          $ setRequestMethod "POST"
+          $ unauthenticatedVaultRequest context "/v1/auth/kubernetes/login"
+      in do
+        _response <- httpLBS request
+        error "TODO"
 
 -- | Look up what mounts are available and what type they have.
 requestMountInfo :: Context -> IO (Either VaultError MountInfo)
 requestMountInfo context =
   let
     cliOptions = cCliOptions context
-    request
-        = setRequestManager
-              (cHttpManager context)
-        $ addVaultToken cliOptions
-        $ setRequestHeader "x-vault-request" ["true"]
-        $ setRequestPath
-              (SBS.pack "/v1/sys/mounts")
-        $ setRequestPort
-              (getOptionsValue oVaultPort cliOptions)
-        $ setRequestHost
-              (SBS.pack (getOptionsValue oVaultHost cliOptions))
-        $ setRequestSecure
-              (getOptionsValue  oConnectTls cliOptions)
-        $ defaultRequest
+    request = addVaultToken cliOptions $ unauthenticatedVaultRequest context "/v1/sys/mounts"
   in do
     -- 'httpLBS' throws an IO Exception ('HttpException') if it fails to complete the request.
     -- We intentionally don't capture this here, but handle it with the retries in 'vaultEnv' instead.
@@ -408,17 +471,8 @@ requestSecret :: Context -> String -> IO (Either VaultError VaultData)
 requestSecret context secretPath =
   let
     cliOptions = cCliOptions context
-    retryPolicy = vaultRetryPolicy (cCliOptions context)
-    request
-        = setRequestManager
-            (cHttpManager context)
-        $ addVaultToken     cliOptions
-        $ setRequestHeader "x-vault-request" ["true"]
-        $ setRequestPath    (SBS.pack secretPath)
-        $ setRequestPort    (getOptionsValue oVaultPort cliOptions)
-        $ setRequestHost    (SBS.pack (getOptionsValue oVaultHost cliOptions))
-        $ setRequestSecure  (getOptionsValue oConnectTls cliOptions)
-        $ defaultRequest
+    retryPolicy = vaultRetryPolicy cliOptions
+    request = addVaultToken cliOptions $ unauthenticatedVaultRequest context secretPath
 
     getSecret :: Retry.RetryStatus -> IO (Either VaultError VaultData)
     getSecret _retryStatus = catch (doRequest secretPath request) httpErrorHandler
@@ -449,7 +503,7 @@ requestSecrets context mountInfo secrets = do
 lookupSecrets :: MountInfo -> [Secret] -> Map.Map String VaultData -> Either VaultError [EnvVar]
 lookupSecrets mountInfo secrets vaultData = forM secrets $ \secret ->
   let secretData = Map.lookup (secretRequestPath mountInfo secret) vaultData
-      secretValue = secretData >>= (\(VaultData vd) -> HM.lookup (sKey secret) vd)
+      secretValue = secretData >>= (\(VaultData vd) -> HashMap.lookup (sKey secret) vd)
       toEnvVar (Aeson.String val) = Right (sVarName secret, unpack val)
       toEnvVar _                  = Left (WrongType secret)
   in maybe (Left $ KeyNotFound secret) toEnvVar $ secretValue
@@ -519,5 +573,9 @@ vaultErrorLogMessage vaultError =
       Unspecified status resp ->
         "Received an error that I don't know about (" <> show status
         <> "): " <> (LBS.unpack resp)
+      KubernetesJwtFailedRead ->
+        "Failed to read '" <> kubernetesJwtPath <> "'."
+      KubernetesJwtInvalidUtf8 ->
+        "Contents of '" <> kubernetesJwtPath <> "' is not valid UTF-8."
   in
     "[ERROR] " <> description

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -565,7 +565,7 @@ vaultErrorLogMessage vaultError =
       BadRequest resp ->
         "Made a bad request: " <> (LBS.unpack resp)
       Forbidden ->
-        "Invalid Vault token"
+        "Forbidden"
       InvalidUrl secretPath ->
         "Secret " <> secretPath <> " contains characters that are illegal in URLs"
       BadJSONResp body msg ->

--- a/default.nix
+++ b/default.nix
@@ -8,5 +8,7 @@
       niv
       perl          # For "prove"
       python3
+      stack
+      vault
     ];
   }

--- a/default.nix
+++ b/default.nix
@@ -3,9 +3,10 @@
   with pkgs; buildEnv {
     name = "vaultenv-devenv";
     paths = [
-      stack
-      vault
       cachix
+      glibcLocales  # So you can export LOCALE_ARCHIVE=$(nix path-info)/lib/locale/locale-archive.
       niv
+      perl # For "prove"
+      python3
     ];
   }

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
       cachix
       glibcLocales  # So you can export LOCALE_ARCHIVE=$(nix path-info)/lib/locale/locale-archive.
       niv
-      perl # For "prove"
+      perl          # For "prove"
       python3
     ];
   }

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -58,9 +58,9 @@ data AuthMethod
   -- specific, so we can use `max` as a sensible merge operation.
   = AuthNone
     -- ^ Do not include an x-vault-token header at all.
-  | AuthKubernetes
+  | AuthKubernetes Text
     -- ^ Use Vault's Kubernetes authentication [1] to obtain a Vault token, then
-    -- use that as the x-vault-token.
+    -- use that as the x-vault-token. The value is the role to use.
     --
     -- [1]: https://www.vaultproject.io/docs/auth/kubernetes)
   | AuthVaultToken Text
@@ -158,9 +158,9 @@ instance Show (Options valid complete) where
     , "Port:                  " ++ showSpecified (oVaultPort opts)
     , "Addr:                  " ++ showSpecified (oVaultAddr opts)
     , "Authentication method: " ++ case oAuthMethod opts of
-        AuthVaultToken _ -> "Specified X-Vault-Token"
-        AuthKubernetes   -> "Kubernetes service account"
-        AuthNone         -> "None"
+        AuthVaultToken _    -> "Specified X-Vault-Token"
+        AuthKubernetes role -> "Kubernetes service account, role: " <> (Text.unpack role)
+        AuthNone            -> "None"
     , "Secret file:           " ++ showSpecifiedString (oSecretFile opts)
     , "Command:               " ++ showSpecifiedString (oCmd opts)
     , "Arguments:             " ++ showSpecified (oArgs opts)
@@ -388,7 +388,9 @@ parseEnvOptions envVars
   , oVaultAddr      = lookupVaultAddr
   , oAuthMethod     = case lookupEnvString "VAULT_TOKEN" of
       Just token -> AuthVaultToken (Text.pack token)
-      Nothing    -> AuthNone
+      Nothing    -> case lookupEnvString "VAULTENV_KUBERNETES_ROLE" of
+        Just role -> AuthKubernetes (Text.pack role)
+        Nothing   -> AuthNone
   , oSecretFile     = lookupEnvString   "VAULTENV_SECRETS_FILE"
   , oCmd            = lookupEnvString   "CMD"
   , oArgs           = lookupStringList  "ARGS..."
@@ -557,12 +559,14 @@ optionsParser = Options
       <> metavar "TOKEN"
       <> help "Token to authenticate to Vault with. Also configurable via VAULT_TOKEN."
 
-    authFallback
-      =  flag AuthNone AuthKubernetes
-      $  long "auth-kubernetes"
-      <> help "Authenticate using Kubernetes service account in /var/run/secrets/kubernetes.io."
+    kubernetesRole
+      =  option (AuthKubernetes  <$> str)
+      $  long "kubernetes-role"
+      <> metavar "ROLE"
+      <> help ("Authenticate using Kubernetes service account in /var/run/secrets/kubernetes.io, " ++
+          "with the given role. Also configurable via VAULTENV_KUBERNETES_ROLE.")
 
-    auth = token <|> authFallback
+    auth = token <|> kubernetesRole <|> pure AuthNone
 
     secretsFile
       =  maybeStrOption

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -24,10 +24,11 @@ module Config
 
 import Control.Applicative ((<|>))
 import Control.Monad(when)
-import Data.List (intercalate)
-import Data.Maybe (fromJust, fromMaybe, isNothing, isJust)
 import Data.Char (isDigit)
 import Data.Either (lefts, rights, isLeft)
+import Data.List (intercalate)
+import Data.Maybe (fromJust, fromMaybe, isNothing, isJust)
+import Data.Text (Text)
 import Data.Version (showVersion)
 import Network.URI (URI(..), URIAuth(..), parseURI)
 import Options.Applicative (value, long, auto, option, metavar, help, flag,
@@ -41,6 +42,7 @@ import System.Exit (die)
 import Text.Read (readMaybe)
 
 import qualified Configuration.Dotenv as DotEnv
+import qualified Data.Text as Text
 import qualified Options.Applicative as OptParse
 import qualified System.Directory as Dir
 
@@ -61,7 +63,7 @@ data AuthMethod
     -- use that as the x-vault-token.
     --
     -- [1]: https://www.vaultproject.io/docs/auth/kubernetes)
-  | AuthVaultToken String
+  | AuthVaultToken Text
     -- ^ Provide the x-vault-token header, with this value.
   deriving (Eq, Ord, Show)
 
@@ -385,7 +387,7 @@ parseEnvOptions envVars
   , oVaultPort      = lookupEnvInt      "VAULT_PORT"
   , oVaultAddr      = lookupVaultAddr
   , oAuthMethod     = case lookupEnvString "VAULT_TOKEN" of
-      Just token -> AuthVaultToken token
+      Just token -> AuthVaultToken (Text.pack token)
       Nothing    -> AuthNone
   , oSecretFile     = lookupEnvString   "VAULTENV_SECRETS_FILE"
   , oCmd            = lookupEnvString   "CMD"

--- a/src/Response.hs
+++ b/src/Response.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Types to hold and json-decode responses from Vault.
+module Response
+  ( ClientToken (..)
+  ) where
+
+import Data.Aeson (FromJSON, (.:))
+import Data.Text (Text)
+
+import qualified Data.Aeson as Aeson
+
+-- | The "client_token" field from an /auth/kubernetes/login response.
+newtype ClientToken = ClientToken Text deriving (Eq, Show)
+
+instance FromJSON ClientToken where
+  parseJSON = Aeson.withObject "AuthResponse" $ \obj -> do
+    auth <- obj .: "auth"
+    clientToken <- auth .: "client_token"
+    pure $ ClientToken clientToken

--- a/test/ResponseSpec.hs
+++ b/test/ResponseSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module ResponseSpec where
+
+import Test.Hspec (SpecWith, describe, it, shouldBe)
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LazyByteString
+
+import Response (ClientToken (..))
+
+-- Example response from /v1/auth/kubernetes/login
+-- Secrets are from a test setup, these are not real secrets.
+loginResponse :: LazyByteString.ByteString
+loginResponse = 
+  -- Replace single quotes (U+0027) with double quotes (U+0022), so we can write
+  -- the json string here as a string literal without too many escapes.
+  LazyByteString.map (\case
+    0x27 -> 0x22
+    x    -> x
+  ) "{'request_id':'43cfeccb-ebd6-aa9f-bcd0-e1c184b625ae','lease_id':'','renewable':false,'lease_duration':0,'data':null,'wrap_info':null,'warnings':null,'auth':{'client_token':'s.J1hknwSvoU5iDB7QfAJ2G15V','accessor':'u3D5ESJ0OzenuqwUdSX87VTZ','policies':['default','testapp-kv-ro'],'token_policies':['default','testapp-kv-ro'],'metadata':{'role':'vaultenv-test-role','service_account_name':'test-vault-auth','service_account_namespace':'default','service_account_secret_name':'','service_account_uid':'0036f224-8b4e-4bd2-b298-560b7b39c011'},'lease_duration':86400,'renewable':true,'entity_id':'349d417f-d5d9-2ae5-a042-b801848334a7','token_type':'service','orphan':true}}"
+
+spec :: SpecWith ()
+spec = do
+  describe "Response.ClientToken" $ do
+    it "can be parsed from json" $ do
+      Aeson.eitherDecode loginResponse `shouldBe` Right (ClientToken "s.J1hknwSvoU5iDB7QfAJ2G15V")

--- a/test/integration/kubernetes_auth.py
+++ b/test/integration/kubernetes_auth.py
@@ -278,19 +278,16 @@ def run_vault_server() -> subprocess.Popen:
 
     Return a handle to the Vault server process.
     """
-    # Listen on 0.0.0.0, not just 127.0.0.1, such that the bridged Minikube
-    # network can also access it.
-    env = {
-        "VAULT_TOKEN": "integration",
-        "VAULT_HOST": "0.0.0.0",
-        "VAULT_PORT": "8200",
-        "VAULT_ADDR": "http://0.0.0.0:8200",
-        # Pass through the PATH, so we can locate the vault binary.
-        "PATH": os.getenv("PATH"),
-    }
-
     vault_server = subprocess.Popen(
-        ["vault", "server", "-dev", "-dev-root-token-id=integration"],
+        [
+            "vault",
+            "server",
+            "-dev",
+            "-dev-root-token-id=integration",
+            # Listen on 0.0.0.0 so the birdged Minikube network can also reach
+            # the server.
+            "-dev-listen-address", "0.0.0.0:8200",
+        ],
         stdin=subprocess.DEVNULL,
         # TODO: Enable after debug complete.
         #stdout=subprocess.DEVNULL,

--- a/test/integration/kubernetes_auth.py
+++ b/test/integration/kubernetes_auth.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+"""
+Verify Vault Kubernetes authentication.
+
+WARNING
+This script expects a (local) Kubernetes cluster to be running (tested with
+minikube) and it runs arbitrary `kubectl` commands. Do not run this with kubectl
+pointed at a production cluster!
+"""
+
+import os
+import signal
+import base64
+import subprocess
+import textwrap
+import time
+
+from typing import Any, Set
+from pathlib import Path
+
+import tap
+
+
+def kubectl(*args: str, **kwargs: Any) -> subprocess.CompletedProcess:
+    return subprocess.run(['kubectl', *args], **kwargs)
+
+
+def vault(*args: str, **kwargs: Any) -> subprocess.CompletedProcess:
+    return subprocess.run(['vault', *args], **kwargs)
+
+
+def main() -> None:
+    """
+    """
+    tap.plan(4)
+
+    tap.diagnose("Setting up Kubernetes service account ...")
+    kubectl(
+        '--namespace', 'default', 'create', 'serviceaccount', 'test-vault-auth',
+        check=False,
+    )
+    kubectl(
+        'apply', '--filename', '-',
+        input=textwrap.dedent(
+            """\
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: role-tokenreview-binding
+              namespace: default
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: system:auth-delegator
+            subjects:
+            - kind: ServiceAccount
+              name: test-vault-auth
+              namespace: default
+            """),
+        encoding='utf-8',
+        check=True,
+    )
+
+    tap.diagnose("Starting Vault server ...")
+    vault_server = run_vault_server()
+
+    # Ensure that all of the `vault` calls below connect over http to the dev
+    # server.
+    os.environ["VAULT_ADDR"] = "http://127.0.0.1:8200"
+
+    tap.diagnose("Adding policy and test value to Vault ...")
+    vault(
+        "policy", "write", "testapp-kv-ro", "-",
+        input=textwrap.dedent(
+            """\
+            path "secret/data/testapp/*" {
+                capabilities = ["read", "list"]
+            }
+            """
+        ),
+        encoding="utf-8",
+        check=True,
+    )
+    vault(
+        "kv",
+        "put",
+        "secret/testapp/config",
+        "username=vaultenvtestuser",
+        "password=hunter2",
+        "ttl=30s",
+        check=True,
+    )
+
+    # Get the name of the service account and export it where Vault can find it.
+    vault_service_account_name = kubectl(
+        "get", "sa", "test-vault-auth", "--output", "jsonpath={.secrets[*]['name']}",
+        capture_output=True,
+        check=True,
+        encoding='utf-8',
+    ).stdout
+    os.environ["VAULT_SA_NAME"] = vault_service_account_name
+    if vault_service_account_name.startswith('test-vault-auth'):
+        tap.ok(f"Vault service account created: {vault_service_account_name}")
+    else:
+        tap.not_ok("No valid Vault service account.")
+
+    service_account_jwt_b64 = kubectl(
+        "get", "secret", vault_service_account_name, "--output", "go-template={{ .data.token }}",
+        capture_output=True,
+        check=True,
+        encoding='utf-8',
+    ).stdout
+    service_account_jwt = base64.b64decode(service_account_jwt_b64).decode('utf-8')
+
+    kubernetes_ca_cert_b64 = kubectl(
+        "config", "view", "--raw", "--minify", "--flatten", "--output", "jsonpath={.clusters[].cluster.certificate-authority-data}",
+        capture_output=True,
+        check=True,
+        encoding='utf-8',
+    ).stdout
+    kubernetes_ca_cert = base64.b64decode(kubernetes_ca_cert_b64).decode('utf-8')
+
+    kubernetes_host = kubectl(
+        "config", "view", "--raw", "--minify", "--flatten", "--output",
+        "jsonpath={.clusters[].cluster.server}'",
+        capture_output=True,
+        check=True,
+        encoding='utf-8',
+    ).stdout
+
+    vault("auth", "enable", "kubernetes", check=True)
+    vault(
+        "write",
+        "auth/kubernetes/config",
+        f"token_reviewer_jwt={service_account_jwt}",
+        f"kubernetes_host={kubernetes_host}",
+        f"kubernetes_ca_cert={kubernetes_ca_cert}",
+        "issuer=https://kubernetes.default.svc.cluster.local",
+        check=True,
+    )
+
+    vault(
+        "write",
+        "auth/kubernetes/role/vaultenv-test-role",
+        "bound_service_account_names=test-vault-auth",
+        "bound_service_account_namespaces=default",
+        "policies=testapp-kv-ro",
+        "ttl=24h",
+        check=True,
+    )
+
+    # We need to kill and restart the server or the kernel will accept the TCP
+    # connections while the Vault server is paused.
+    vault_server.terminate()
+    wait_seconds = 5
+    vault_server.wait(timeout=wait_seconds)
+
+
+def run_vaultenv(secrets_file: Path) -> subprocess.Popen:
+    """
+    Run Vaultenv with the secrets file from the given path.
+
+    Return a subprocess.Popen-handle to the running Vaultenv process.
+    """
+    return subprocess.Popen(
+        [
+            "stack",
+            "run",
+            "--no-nix-pure",
+            "--",
+            "vaultenv",
+            "--no-connect-tls",
+            "--host",
+            os.environ["VAULT_HOST"],
+            "--port",
+            os.environ["VAULT_PORT"],
+            "--secrets-file",
+            str(secrets_file),
+            "/usr/bin/env",
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=None,  # Inherit calling process's stderr
+        text=True,
+    )
+
+
+def run_minikube() -> subprocess.Popen:
+    """
+    Run a local Kubernetes cluster with Minikube.
+    """
+    minikube = subprocess.Popen(
+        [
+            "minikube",
+            "start",
+            # The KVM2 driver is the only one that I have been able to get
+            # running without root privileges. On Arch it requires the following
+            # packages:
+            # * libvirt
+            # * qemu
+            # * dnsmasq
+            # * ebtables
+            # Also, your user needs to be a member of the libvirt group, and the
+            # libvirtd systemd service must be running.
+            # Alternative backends that I could not get to work.
+            # * Docker (when your user is not part of the "docker" group, which
+            #   it should not be, because it is effectively root.
+            # * Podman
+            # * None
+            "--driver",
+            "kvm2",
+        ],
+        stdin=subprocess.DEVNULL,
+        #stdout=subprocess.DEVNULL,
+        #stderr=subprocess.DEVNULL,
+    )
+
+
+def run_vault_server() -> subprocess.Popen:
+    """
+    Run the Vault dev server with Kubernetes auth enabled.
+
+    Return a handle to the Vault server process.
+    """
+    env = {
+        "VAULT_TOKEN": "integration",
+        "VAULT_HOST": "127.0.0.1",
+        "VAULT_PORT": "8200",
+        "VAULT_ADDR": "http://127.0.0.1:8200",
+        # Pass through the PATH, so we can locate the vault binary.
+        "PATH": os.getenv("PATH"),
+    }
+
+    vault_server = subprocess.Popen(
+        ["vault", "server", "-dev", "-dev-root-token-id=integration"],
+        stdin=subprocess.DEVNULL,
+        # TODO: Enable after debug complete.
+        #stdout=subprocess.DEVNULL,
+        #stderr=subprocess.DEVNULL,
+    )
+    sleep_seconds = 1
+    time.sleep(sleep_seconds)
+
+    return vault_server
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/kubernetes_auth_container.nix
+++ b/test/integration/kubernetes_auth_container.nix
@@ -3,12 +3,71 @@
 let
   vaultenv = (import ../../nix/release.nix).vaultenv;
 
+  secretsFile = pkgs.writeTextFile {
+    name = "test.secrets";
+    destination = "/lib/test.secrets";
+    text =
+      ''
+      testapp/config#username
+      testapp/config#password
+      '';
+  };
+
+  # TODO: Is this needed?
+  hostsFile = pkgs.writeTextFile {
+    name = "hosts";
+    destination = "/etc/hosts";
+    text = "";
+  };
+
+  # TODO: Is this needed?
+  resolvConf = pkgs.writeTextFile {
+    name = "resolv.conf";
+    destination = "/etc/resolv.conf";
+    text = "";
+  };
+
+  # When Vaultenv runs in the container in the pod, it needs to access Vault
+  # that is running outside. When the pod is running in Minikube, Vaultenv can
+  # reach the host network at host.minikube.internal. Its ip address is written
+  # in /etc/hosts, which is mounted by Minikube inside the container. But we
+  # still need to convince glibc to actually read /etc/hosts, and for that, we
+  # need to provide an nsswitch config that has a "hosts: files" line.
+  nsswitch = pkgs.writeTextFile {
+    name = "nsswitch.conf";
+    destination = "/etc/nsswitch.conf";
+    text =
+      ''
+      # TODO: Are the non-hosts lines needed?
+      passwd:         files
+      group:          files
+      shadow:         files
+      gshadow:        files
+
+      hosts:          files dns
+      networks:       files
+
+      protocols:      db files
+      services:       db files
+      ethers:         db files
+      rpc:            db files
+
+      netgroup:       nis
+      '';
+  };
+
   container = pkgs.dockerTools.buildLayeredImage {
     name = "vaultenv/vaultenv";
     tag = "test";
     contents = [
       vaultenv
+      secretsFile
+      hostsFile
+      resolvConf
+      nsswitch
       pkgs.coreutils
+      pkgs.bash
+      pkgs.iputils
     ];
   };
 

--- a/test/integration/kubernetes_auth_container.nix
+++ b/test/integration/kubernetes_auth_container.nix
@@ -13,20 +13,6 @@ let
       '';
   };
 
-  # TODO: Is this needed?
-  hostsFile = pkgs.writeTextFile {
-    name = "hosts";
-    destination = "/etc/hosts";
-    text = "";
-  };
-
-  # TODO: Is this needed?
-  resolvConf = pkgs.writeTextFile {
-    name = "resolv.conf";
-    destination = "/etc/resolv.conf";
-    text = "";
-  };
-
   # When Vaultenv runs in the container in the pod, it needs to access Vault
   # that is running outside. When the pod is running in Minikube, Vaultenv can
   # reach the host network at host.minikube.internal. Its ip address is written
@@ -36,24 +22,7 @@ let
   nsswitch = pkgs.writeTextFile {
     name = "nsswitch.conf";
     destination = "/etc/nsswitch.conf";
-    text =
-      ''
-      # TODO: Are the non-hosts lines needed?
-      passwd:         files
-      group:          files
-      shadow:         files
-      gshadow:        files
-
-      hosts:          files dns
-      networks:       files
-
-      protocols:      db files
-      services:       db files
-      ethers:         db files
-      rpc:            db files
-
-      netgroup:       nis
-      '';
+    text = "hosts: files dns";
   };
 
   container = pkgs.dockerTools.buildLayeredImage {
@@ -62,8 +31,6 @@ let
     contents = [
       vaultenv
       secretsFile
-      hostsFile
-      resolvConf
       nsswitch
       pkgs.coreutils
       pkgs.bash

--- a/test/integration/kubernetes_auth_container.nix
+++ b/test/integration/kubernetes_auth_container.nix
@@ -8,8 +8,8 @@ let
     destination = "/lib/test.secrets";
     text =
       ''
-      testapp/config#username
-      testapp/config#password
+      data/testapp/config#username
+      data/testapp/config#password
       '';
   };
 

--- a/test/integration/kubernetes_auth_container.nix
+++ b/test/integration/kubernetes_auth_container.nix
@@ -1,0 +1,16 @@
+{ pkgs ? (import ../../nix/nixpkgs-pinned.nix) {} }:
+
+let
+  vaultenv = (import ../../nix/release.nix).vaultenv;
+
+  container = pkgs.dockerTools.buildLayeredImage {
+    name = "vaultenv/vaultenv";
+    tag = "test";
+    contents = [
+      vaultenv
+      pkgs.coreutils
+    ];
+  };
+
+in
+  container


### PR DESCRIPTION
## Background

Currently, Vaultenv requires you to have a Vault token. When used in Kubernetes, typically this Vault token is not available directly. Instead, Kubernetes mounts a file into `/var/run/secrets` that contains a Kubernetes service account token, and you can then use this token with [the Vault Kubernetes authentication endpoint](https://www.vaultproject.io/docs/auth/kubernetes) to obtain the Vault token. This authentication method also requires specifying a _role_.

## Changes

Add a new option, `--kubernetes-role`, which is an alternative to `--vault-token`. If `--kubernetes-role` is supplied, Vaultenv will read the Kubernetes token from `/var/run/secrets/kubernetes.io/serviceaccount/token`, authenticate to Vault with that token and the given role, and that produces a token which Vaultenv will use for subsequent requests.

## Testing

This feature is inherently complex: it requires a Kubernetes cluster, which is already a very complex piece of software that consists of multiple moving parts. On top of that it requires a Vault server, and then Vault needs to be configured to use Kubernetes. I wrote a Python script to test Vaultenv with Kubernetes authentication, and eventually I got it working on my machine with Minikube, but it is not fully automated, and likely the test will not work out of the box in other environments. Making this run on CI would be quite an effort and this is not my goal right now.

In addition to this semi-manual testing, I will be testing this against a production Kubernetes cluster before marking this pull request as ready for review.

## Alternatives

Apparently, newer versions of Kubernetes can act as an OIDC provider, and [Vault supports OIDC authentication as well](https://www.vaultproject.io/docs/auth/jwt). OIDC authentication is useful outside of Kubernetes. So maybe this approach of using Kubernetes authentication in Vault is already obsolete. Still, it’s a good way to explore what alternative authentication methods can look like, and I think the work in this PR will make it easier to add OIDC support in the future.