### PR TITLE
Bump `GHC` from `8.6.5` to `9.0.2`

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65f4c39a40e6ed4343dd94017c3ed81f416cd3b4",
-        "sha256": "0l09dbz9rx3id5blpj5mkzvn5fgycnpqxz30mbxgxrrmxvrgkf76",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "sha256": "0x5j9q1vi00c6kavnjlrwl3yy1xs60c34pkygm49dld2sgws7n0a",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/65f4c39a40e6ed4343dd94017c3ed81f416cd3b4.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/30d3d79b7d3607d56546dd2a6b49e156ba0ec634.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "static-haskell-nix": {

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -11,7 +11,7 @@ in
         # bundled with all the dependencies listed in `haskell-dependencies.nix`.
         # This allows us to have stack use the dependencies from nixpkgs,
         # instead of fetching them itself.
-        ghc = nixpkgs.haskell.packages.ghc865.ghcWithPackages getDependencies;
+        ghc = nixpkgs.haskell.packages.ghc902.ghcWithPackages getDependencies;
         buildInputs = with nixpkgs; [
           glibcLocales
         ];

--- a/nix/vaultenv-static.nix
+++ b/nix/vaultenv-static.nix
@@ -35,7 +35,7 @@ let
   # This has to match the compiler used in the Stackage snapshot.
   # Update this when the Stackage snapshot changes the version of
   # GHC it uses.
-  compiler = "ghc865";
+  compiler = "ghc902";
 
   # Pin versions of static-haskell-nix and nixpkgs.
   sources = import ./sources.nix;

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # compiler used in this Stackage snapshot.
 # This value has a companion file named `stack-static-build.yaml`, used for static builds.
 # When updating this resolver, update that file as well.
-resolver: ghc-8.6.5
+resolver: ghc-9.0.2
 
 packages:
   - "."


### PR DESCRIPTION
XRef: https://github.com/channable/vaultenv/issues/118

Bumps GHC from `8.6.5` to `9.0.2`. This is done in preparation for moving to `aeson 2.0.*`.