### PR TITLE
 Bump `aeson` from `1.5.*` to `2.0.*`

### DIFF
--- a/nix/haskell-dependencies.nix
+++ b/nix/haskell-dependencies.nix
@@ -19,6 +19,7 @@ haskellPackages:
       megaparsec
       optparse-applicative
       parser-combinators
+      quickcheck-instances
       retry
       text
       unix

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -1,0 +1,3 @@
+self: super: {
+  hashable = super.hashable_1_4_0_2;
+}

--- a/nix/nixpkgs-pinned.nix
+++ b/nix/nixpkgs-pinned.nix
@@ -8,7 +8,7 @@ let
   sources = import ./sources.nix;
 
   nixpkgs = import sources.nixpkgs {
-    overlays = overlays;
+    overlays = [(import ./overlay.nix)] ++ overlays;
     config = {
       imports = [ config ];
     };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,6 @@
+self: super:
+let
+  haskellOverlay = import ./haskell-overlay.nix;
+in {
+  Ghc902Packages = super.haskell.packages.ghc902.extend haskellOverlay;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65f4c39a40e6ed4343dd94017c3ed81f416cd3b4",
-        "sha256": "0l09dbz9rx3id5blpj5mkzvn5fgycnpqxz30mbxgxrrmxvrgkf76",
+        "rev": "d08394e7cd5c7431a1e8f53b7f581e74ee909548",
+        "sha256": "04s6ajl82zgxic20ymcz8b9a8sr14p7c69f1axvagypcmjnqz47i",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/65f4c39a40e6ed4343dd94017c3ed81f416cd3b4.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d08394e7cd5c7431a1e8f53b7f581e74ee909548.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "static-haskell-nix": {

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,10 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
+      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
 
   fetch_local = spec: spec.path;
 
@@ -98,7 +100,10 @@ let
       saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
       ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
     in
-      if ersatz == "" then drv else ersatz;
+      if ersatz == "" then drv else
+        # this turns the string into an actual Nix path (for both absolute and
+        # relative paths)
+        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -11,7 +11,7 @@ in
         # bundled with all the dependencies listed in `haskell-dependencies.nix`.
         # This allows us to have stack use the dependencies from nixpkgs,
         # instead of fetching them itself.
-        ghc = nixpkgs.haskell.packages.ghc865.ghcWithPackages getDependencies;
+        ghc = nixpkgs.Ghc902Packages.ghcWithPackages getDependencies;
         buildInputs = with nixpkgs; [
           glibcLocales
         ];

--- a/nix/vaultenv-static.nix
+++ b/nix/vaultenv-static.nix
@@ -35,7 +35,7 @@ let
   # This has to match the compiler used in the Stackage snapshot.
   # Update this when the Stackage snapshot changes the version of
   # GHC it uses.
-  compiler = "ghc865";
+  compiler = "ghc902";
 
   # Pin versions of static-haskell-nix and nixpkgs.
   sources = import ./sources.nix;

--- a/package.yaml
+++ b/package.yaml
@@ -55,3 +55,4 @@ tests:
     - hspec-expectations
     - directory
     - QuickCheck
+    - quickcheck-instances

--- a/src/KeyMap.hs
+++ b/src/KeyMap.hs
@@ -1,0 +1,25 @@
+-- | KeyMap, extending Aeson.KeyMap to support replacing HashMap.
+module KeyMap
+  ( KeyMap
+  , lookupDefault
+  , lookup
+  , mapMaybe
+  , fromList
+  , toList
+
+  , Key
+  , fromText
+  , toText
+  , fromString
+  , toString
+  ) where
+
+import Data.Aeson.Key    (Key, fromText, toText, fromString, toString)
+import Data.Aeson.KeyMap (KeyMap, mapMaybe, fromList, toList)
+import Data.Maybe (fromMaybe)
+
+import qualified Data.Aeson.KeyMap as KM
+
+-- | lookupDefault for KeyMap based on lookupDefault from HashMap.
+lookupDefault :: v -> Key -> KeyMap v -> v
+lookupDefault d k km = fromMaybe d $ KM.lookup k km

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # compiler used in this Stackage snapshot.
 # This value has a companion file named `stack-static-build.yaml`, used for static builds.
 # When updating this resolver, update that file as well.
-resolver: ghc-8.6.5
+resolver: ghc-9.0.2
 
 packages:
   - "."

--- a/test/KeyMapSpec.hs
+++ b/test/KeyMapSpec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module KeyMapSpec where
+
+import Data.Text (Text)
+import Test.Hspec
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+
+import qualified Data.HashMap.Internal.Strict as HM
+
+import qualified KeyMap as KM
+
+mapFirst :: (a->b) -> [(a,c)] -> [(b,c)]
+mapFirst _ [] = []
+mapFirst f ((x,y) : rest) = (f x, y) : mapFirst f rest
+
+spec :: SpecWith ()
+spec =
+  describe "KeyMap" $ do
+    it "lookupDefault matches the HashMap implementation" $
+      property $ \((fallback :: Text), key, mapping) ->
+        let keyMapValue = KM.lookupDefault fallback (KM.fromText key) (KM.fromList $ mapFirst KM.fromText mapping)
+            hashMapValue = HM.lookupDefault fallback key (HM.fromList mapping)
+        in keyMapValue `shouldBe` hashMapValue


### PR DESCRIPTION
XRef: https://github.com/channable/vaultenv/issues/118

This is the first try to overwrite the packages such that `stack` can compile with `aeson 2.0.*` available.

This adds a Haskell overlay in the process.

This overwrites the minimal set of packages in the `./nix/haskell-overlay.nix` to enable `aeson 2.0.*`.

---

The current state is that the dependencies compile but the package itself needs to be modified to work with the updated `aeson` package.

```
$ nix run -c stack build
vaultenv-real> build (lib + exe)
Preprocessing library for vaultenv-real-0.14.0..
Building library for vaultenv-real-0.14.0..
Preprocessing executable 'vaultenv' for vaultenv-real-0.14.0..
Building executable 'vaultenv' for vaultenv-real-0.14.0..
[1 of 2] Compiling Main [SecretsFile changed]

/home/reinier/channable/vaultenv/app/Main.hs:156:65: error:
    • Couldn't match type: Data.Aeson.KeyMap.KeyMap Aeson.Value
                     with: HashMap Text Aeson.Value
      Expected: HashMap Text Aeson.Value
        Actual: Aeson.Object
    • In the second argument of ‘mapMaybe’, namely ‘obj’
      In the first argument of ‘MountInfo’, namely
        ‘(mapMaybe (\ v -> parseMaybe getType v) obj)’
      In the second argument of ‘($)’, namely
        ‘MountInfo (mapMaybe (\ v -> parseMaybe getType v) obj)’
    |
156 |         pure $ MountInfo (mapMaybe (\v -> parseMaybe getType v) obj)
    |                                                                 ^^^

--  While building package vaultenv-real-0.14.0 (scroll up to its section to see the error) using:
      /home/reinier/.stack/setup-exe-cache/x86_64-linux-nix/Cabal-simple_mPHDZzAJ_3.4.1.0_ghc-9.0.2 --builddir=.stack-work/dist/x86_64-linux-nix/Cabal-3.4.1.0 build lib:vaultenv-real exe:vaultenv --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1

```