### PR TITLE
Replace references to nix run with nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,8 +429,8 @@ from a Nix cache, to not have to recompile all of Haskell and its dependencies.
 To set up the cache, execute these commands once before building:
 
 ```console
-$ nix run -c cachix use static-haskell-nix
-$ nix run -c cachix use channable-public
+$ nix shell --file default.nix -c cachix use static-haskell-nix
+$ nix shell --file default.nix -c cachix use channable-public
 ```
 
 Note that the build process via Nix is not (yet) reproducible, which means that
@@ -449,7 +449,7 @@ test `vaultenv`.
 Get this shell with:
 
 ```
-$ nix run
+$ nix shell --file default.nix
 ```
 
 ## Future work

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
  1. Tag: `git tag -a v<VERSION>`. Write a changelog.
  1. `git push origin master --tags`
  1. Build the static version of `vaultenv` and the Debian package by running
-    `nix run -c ./package/build_package.sh`.
+    `nix shell --file default.nix -c ./package/build_package.sh`.
  1. Go to https://github.com/channable/vaultenv/releases
  1. Click "Draft a new release". Add the binary from the Nix output and the
     .deb package.


### PR DESCRIPTION
This replaces references references to `nix run` (from Nix 2.3) to `nix shell` (used from Nix 2.4 and later).