### PR TITLE
Allow overwriting over environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Available options:
                            Defaults to 8. Pass 0 to disable the limit. Also
                            configurable through
                            VAULTENV_MAX_CONCURRENT_REQUESTS.
+  --duplicate-variable-behavior error | keep | overwrite
+                           Changes the behavior of duplicate variables. 'error`
+                           produces an error for duplicate variables. 'keep'
+                           keeps the value already in the environment , ignoring
+                           the secret. 'overwrite' overwrite the environment
+                           variable in favor of the secret. Default to 'error'.
+                           Also configurable through
+                           VAULTENV_DUPLICATE_VARIABLE_BEHAVIOR.
 ```
 
 ## Configuration
@@ -331,6 +339,7 @@ VAULTENV_RETRY_ATTEMPTS:        9
 VAULTENV_LOG_LEVEL:             Error
 VAULTENV_USE_PATH:              True
 VAULTENV_MAX_CONCURRENT_REQUESTS: 8
+VAULTENV_DUPLICATE_VARIABLE_BEHAVIOR: error
 ```
 In cases where no default nor any value is specified, which is possible for `Token`, `Secret file` and
 `Command`, Vaultenv will give an error that it requires these values to operate.

--- a/test/integration/duplicate_env_var.sh
+++ b/test/integration/duplicate_env_var.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "1..1"
+echo "1..4"
 
 export TESTING_KEY=testing666
 stack exec --no-nix-pure -- vaultenv \
@@ -11,4 +11,46 @@ stack exec --no-nix-pure -- vaultenv \
   /bin/echo "not ok 1 - vaultenv didn't error with duplicate env var"
 
 echo "ok 1 - vaultenv didn't complete"
+
+stack exec --no-nix-pure -- vaultenv \
+  --no-connect-tls \
+  --host ${VAULT_HOST} \
+  --port ${VAULT_PORT} \
+  --duplicate-variable-behavior error \
+  --secrets-file ${VAULT_SEEDS} -- \
+  /bin/echo "not ok 2 - vaultenv didn't error with duplicate env var"
+
+echo "ok 2 - vaultenv didn't complete"
+
+
+stack exec --no-nix-pure -- vaultenv \
+  --no-connect-tls \
+  --host ${VAULT_HOST} \
+  --port ${VAULT_PORT} \
+  --duplicate-variable-behavior keep \
+  --secrets-file ${VAULT_SEEDS} -- \
+  /usr/bin/env \
+  | grep "TESTING_KEY=testing666"
+
+if [ $? -eq 0 ]; then
+  echo "ok 3 - vaultenv passed through test var"
+else
+  echo "not ok 3 - vaultenv didn´t pass through test var"
+fi
+
+stack exec --no-nix-pure -- vaultenv \
+  --no-connect-tls \
+  --host ${VAULT_HOST} \
+  --port ${VAULT_PORT} \
+  --duplicate-variable-behavior overwrite \
+  --secrets-file ${VAULT_SEEDS} -- \
+  /usr/bin/env \
+  | grep "TESTING_KEY=testing42"
+
+if [ $? -eq 0 ]; then
+  echo "ok 4 - vaultenv overwrote test var"
+else
+  echo "not ok 4 - vaultenv didn´t overwrite test var"
+fi
+
 unset TESTING_KEY


### PR DESCRIPTION
Fixes https://github.com/channable/vaultenv/issues/134

Allow us to overwrite the duplicate variables error with a new flag. When enabling this flag, we don't error on duplicate variables, but instead take the ones from the environment already specified.