### PR TITLE
Add support for comments in secrets files

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -49,7 +49,7 @@ import Config (AuthMethod (..), Options(..), parseOptions, unMilliSeconds,
                LogLevel(..), readConfigFromEnvFiles, getOptionsValue,
                Validated, Completed, DuplicateVariableBehavior (..))
 import KeyMap (KeyMap)
-import SecretsFile (Secret(..), SFError(..), readSecretsFile)
+import SecretsFile (Secret(..), readSecretsFile)
 import Response (ClientToken (..))
 
 import qualified KeyMap as KM
@@ -177,7 +177,7 @@ instance FromJSON MountInfo where
 -- function which is responsible for printing an error message and exiting.
 data VaultError
   = SecretNotFound String
-  | SecretFileError SFError
+  | SecretFileError String
   | KeyNotFound Secret
   | WrongType Secret
   | BadRequest LBS.ByteString

--- a/package.yaml
+++ b/package.yaml
@@ -19,16 +19,13 @@ dependencies:
   - http-conduit
   - http-client
   - http-client-openssl
-  - megaparsec
   - network-uri
   - optparse-applicative
-  - parser-combinators
   - retry
   - text
   - unordered-containers
   - unix
   - utf8-string
-  - optparse-applicative
 
 ghc-options: -threaded -Wall -Werror
 

--- a/test/SecretFileSpec.hs
+++ b/test/SecretFileSpec.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 
 import Data.Either (isRight, isLeft)
 
+
 import qualified SecretsFile
 import qualified System.Directory as Dir
 
@@ -21,3 +22,22 @@ spec = do
       let invalidTestFiles = map ("test/invalid/" <>) invalidTestContents
       parseResults <- mapM SecretsFile.readSecretsFile invalidTestFiles
       parseResults `shouldSatisfy` (all isLeft)
+
+    it "parses all v2-comments.secrets as expected" $ do
+      -- This is a regression test, Vaultenv 0.16.0 used to drop the second
+      -- secret.
+      Right parseResults <- SecretsFile.readSecretsFile "test/golden/v2-comments.secrets"
+      parseResults `shouldBe`
+        [ SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "devices/frobnicator"
+          , SecretsFile.sKey = "PASSWORD"
+          , SecretsFile.sVarName = "FROBNICATOR_PASSWORD"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "devices/widgets/turboencabulator"
+          , SecretsFile.sKey = "PIN"
+          , SecretsFile.sVarName = "WIDGET_PIN"
+          }
+        ]

--- a/test/SecretFileSpec.hs
+++ b/test/SecretFileSpec.hs
@@ -25,7 +25,83 @@ spec = do
         parseResult <- SecretsFile.readSecretsFile fname
         parseResult `shouldSatisfy` isLeft
 
-    it "parses all v2-comments.secrets as expected" $ do
+    it "parses v1.secrets as expected" $ do
+      Right parseResults <- SecretsFile.readSecretsFile "test/golden/v1.secrets"
+      parseResults `shouldBe`
+        [ SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo"
+          , SecretsFile.sKey = "bar"
+          , SecretsFile.sVarName = "FOO_BAR"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo/bar"
+          , SecretsFile.sKey = "baz"
+          , SecretsFile.sVarName = "FOO_BAR_BAZ"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "bar"
+          , SecretsFile.sKey = "baz"
+          , SecretsFile.sVarName = "FOO"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo/baz"
+          , SecretsFile.sKey = "quix"
+          , SecretsFile.sVarName = "BAR"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo/single"
+          , SecretsFile.sKey = "underscore"
+          , SecretsFile.sVarName = "single_underscore"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo/double"
+          , SecretsFile.sKey = "underscore"
+          , SecretsFile.sVarName = "double__underscore"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo/double"
+          , SecretsFile.sKey = "underscore"
+          , SecretsFile.sVarName = "_leading_underscore"
+          }
+        ]
+
+    it "parses v2.secrets as expected" $ do
+      Right parseResults <- SecretsFile.readSecretsFile "test/golden/v2.secrets"
+      parseResults `shouldBe`
+        [ SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo"
+          , SecretsFile.sKey = "bar"
+          , SecretsFile.sVarName = "SECRET_FOO_BAR"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "secret"
+          , SecretsFile.sPath = "foo/baz"
+          , SecretsFile.sKey = "bar"
+          , SecretsFile.sVarName = "BAR"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "otherthing"
+          , SecretsFile.sPath = "foo"
+          , SecretsFile.sKey = "bar"
+          , SecretsFile.sVarName = "OTHERTHING_FOO_BAR"
+          }
+        , SecretsFile.Secret
+          { SecretsFile.sMount = "otherthing"
+          , SecretsFile.sPath = "foo/baz"
+          , SecretsFile.sKey = "bar"
+          , SecretsFile.sVarName = "BAR"
+          }
+        ]
+
+    it "parses v2-comments.secrets as expected" $ do
       -- This is a regression test, Vaultenv 0.16.0 used to drop the second
       -- secret.
       Right parseResults <- SecretsFile.readSecretsFile "test/golden/v2-comments.secrets"

--- a/test/golden/v2-comments.secrets
+++ b/test/golden/v2-comments.secrets
@@ -1,0 +1,8 @@
+VERSION 2
+MOUNT secret
+
+FROBNICATOR_PASSWORD=devices/frobnicator#PASSWORD
+
+# This is a comment. It should not inhibit the final entry from being loaded.
+# There can be a second line of comment too.
+WIDGET_PIN=devices/widgets/turboencabulator#PIN

--- a/test/golden/whitespace.secrets
+++ b/test/golden/whitespace.secrets
@@ -1,5 +1,5 @@
 
-VERSION    2
+VERSION 2
 
   MOUNT secret
 stuff/and#things  


### PR DESCRIPTION
## Motivation

I shot myself in my foot because of [this line in the readme](https://github.com/channable/vaultenv/blob/c61036674d3a385523b38e5b30105148e91f6cfd/README.md?plain=1#L295):

> Also: comments are allowed if they start with `#`.

The comment is about `vaultenv.conf`, not about the secrets file, so it’s entirely my own fault. Still, what happens when you mistakenly think that secrets files support comments, and you feed Vaultenv this file?

```
VERSION 2
MOUNT secret
FOO=app#foo

# Comment
BAR=app#bar
```

Then Vaultenv will parse up to the comment, and silently drop the `BAR=` definition.

## Changes

1. Add a new test for a file that has comments. It fails before changing the parser.
2. Extend the tests; before this they only tested that the files can be parsed or not parsed, but they don’t check what the parsed result looks like.
3. Rewrite the parser to support comments.

There was a Megaparsec parser but I found it difficult to introduce comment support. I think using a parser for this creates more confusion (and danger, as it dropped half my input) than a simple split-on-lines, split-on-`=`, split-on-`#`. So I rewrote it without Megaparsec. It is now 100 lines smaller and supports comments.

This makes some breaking changes: the version line must be `VERSION 2`, other whitespace is no longer allowed. I think that’s acceptable but if you prefer to keep it compatible it’s also not too difficult. Either way if you write `VERSION    2` that will fail to parse and not silently result in an unexpected secrets list. Also it is now a bit more lax about what path names and key names it accepts.