### PR TITLE
Nixpkgs update, and crypton-connection upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ of `tutorial.sh`.
 ## Usage
 
 ```
-vaultenv 0.16.0 - run programs with secrets from HashiCorp Vault
+vaultenv 0.16.1 - run programs with secrets from HashiCorp Vault
 
 Usage: vaultenv [--version] [--host HOST] [--port PORT] [--addr ADDR]
                 [--token TOKEN | --github-token TOKEN | --kubernetes-role ROLE]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -36,7 +36,7 @@ import qualified Control.Retry              as Retry
 import qualified Data.Aeson                 as Aeson
 import qualified Data.ByteString            as ByteString
 import qualified Data.ByteString.Char8      as SBS
-import qualified Data.ByteString.Lazy       as LBS hiding (unpack, putStrLn)
+import qualified Data.ByteString.Lazy       as LBS hiding (unpack)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Foldable              as Foldable
 import qualified Data.HashMap.Strict        as HashMap

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,11 @@
-{ pkgs ? import ./nix/nixpkgs-pinned.nix {}
+{ pkgs ? import ./nix/nixpkgs-pinned.nix
+  # Allow vault to be used only as a part of this development shell.
+  # We are not allowing the use of vault as a part of our final package
+  # because vault-1.16.1 is lisenced under BSL-1.1
+  { config.allowUnfreePredicate = pkg:
+      (pkgs.lib.getName pkg) == "vault" &&
+      (pkgs.lib.getVersion pkg) == "1.17.2";
+  }
 }:
   with pkgs; buildEnv {
     name = "vaultenv-devenv";

--- a/nix/haskell-dependencies.nix
+++ b/nix/haskell-dependencies.nix
@@ -7,7 +7,7 @@ haskellPackages:
       async
       base
       bytestring
-      connection
+      crypton-connection
       containers
       directory
       dotenv

--- a/nix/nixpkgs-pinned.nix
+++ b/nix/nixpkgs-pinned.nix
@@ -9,9 +9,7 @@ let
 
   nixpkgs = import sources.nixpkgs {
     overlays = [(import ./overlay.nix)] ++ overlays;
-    config = {
-      imports = [ config ];
-    };
+    inherit config;
   };
 in
 nixpkgs

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,5 +2,5 @@ self: super:
 let
   haskellOverlay = import ./haskell-overlay.nix;
 in {
-  Ghc902Packages = super.haskell.packages.ghc902.extend haskellOverlay;
+  vaultenvHaskellPackages = super.haskell.packages.ghc964.extend haskellOverlay;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5d810f4c74c824ae0fb788103003c6c9d366a08",
-        "sha256": "1lmizli5hbk7hlvss0ixx4zl5g4s77z493lr2xn37csph5xcl3rb",
+        "rev": "453402b94f39f968a7c27df28e060f69e4a50c3b",
+        "sha256": "10ipmhb34ccrbndiryzbgqfdjaw1w7c05wi22yg45m605nxsl3w9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c5d810f4c74c824ae0fb788103003c6c9d366a08.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/453402b94f39f968a7c27df28e060f69e4a50c3b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "static-haskell-nix": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nh2",
         "repo": "static-haskell-nix",
-        "rev": "bd66b86b72cff4479e1c76d5916a853c38d09837",
-        "sha256": "0rnsxaw7v27znsg9lgqk1i4007ydqrc8gfgimrmhf24lv6galbjh",
+        "rev": "481e7d73ca624278ef0f840a0a2ba09e3a583217",
+        "sha256": "0y4hzk1jxp4fdjksg6p1q6g5i4xw7cmb50vg5np7z5ipk4y4gc2x",
         "type": "tarball",
-        "url": "https://github.com/nh2/static-haskell-nix/archive/bd66b86b72cff4479e1c76d5916a853c38d09837.tar.gz",
+        "url": "https://github.com/nh2/static-haskell-nix/archive/481e7d73ca624278ef0f840a0a2ba09e3a583217.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -10,31 +10,50 @@ let
     let
       name' = sanitizeName name + "-src";
     in
-      if spec.builtin or true then
-        builtins_fetchurl { inherit (spec) url sha256; name = name'; }
-      else
-        pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
+    if spec.builtin or true then
+      builtins_fetchurl { inherit (spec) url sha256; name = name'; }
+    else
+      pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
 
   fetch_tarball = pkgs: name: spec:
     let
       name' = sanitizeName name + "-src";
     in
-      if spec.builtin or true then
-        builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
-      else
-        pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
+    if spec.builtin or true then
+      builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
+    else
+      pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
   fetch_git = name: spec:
     let
       ref =
-        if spec ? ref then spec.ref else
+        spec.ref or (
           if spec ? branch then "refs/heads/${spec.branch}" else
-            if spec ? tag then "refs/tags/${spec.tag}" else
-              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
-      submodules = if spec ? submodules then spec.submodules else false;
+          if spec ? tag then "refs/tags/${spec.tag}" else
+          abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!"
+        );
+      submodules = spec.submodules or false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                { }
+            else { };
+        in
+        if nixSupportsSubmodules
+        then { inherit submodules; }
+        else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
-      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
+    builtins.fetchGit
+      ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 
@@ -68,16 +87,16 @@ let
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
-      if builtins.hasAttr "nixpkgs" sources
-      then sourcesNixpkgs
-      else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
-        import <nixpkgs> {}
-      else
-        abort
-          ''
-            Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
-            add a package called "nixpkgs" to your sources.json.
-          '';
+    if builtins.hasAttr "nixpkgs" sources
+    then sourcesNixpkgs
+    else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
+      import <nixpkgs> { }
+    else
+      abort
+        ''
+          Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+          add a package called "nixpkgs" to your sources.json.
+        '';
 
   # The actual fetching function.
   fetch = pkgs: name: spec:
@@ -97,13 +116,13 @@ let
   # the path directly as opposed to the fetched source.
   replace = name: drv:
     let
-      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      saneName = stringAsChars (c: if (builtins.match "[a-zA-Z0-9]" c) == null then "_" else c) name;
       ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
     in
-      if ersatz == "" then drv else
-        # this turns the string into an actual Nix path (for both absolute and
-        # relative paths)
-        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
+    if ersatz == "" then drv else
+      # this turns the string into an actual Nix path (for both absolute and
+      # relative paths)
+    if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 
@@ -114,7 +133,7 @@ let
   );
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/lists.nix#L295
-  range = first: last: if first > last then [] else builtins.genList (n: first + n) (last - first + 1);
+  range = first: last: if first > last then [ ] else builtins.genList (n: first + n) (last - first + 1);
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L257
   stringToCharacters = s: map (p: builtins.substring p 1 s) (range 0 (builtins.stringLength s - 1));
@@ -125,43 +144,46 @@ let
   concatStrings = builtins.concatStringsSep "";
 
   # https://github.com/NixOS/nixpkgs/blob/8a9f58a375c401b96da862d969f66429def1d118/lib/attrsets.nix#L331
-  optionalAttrs = cond: as: if cond then as else {};
+  optionalAttrs = cond: as: if cond then as else { };
 
   # fetchTarball version that is compatible between all the versions of Nix
   builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
-      if lessThan nixVersion "1.12" then
-        fetchTarball ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
-      else
-        fetchTarball attrs;
+    if lessThan nixVersion "1.12" then
+      fetchTarball ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
+    else
+      fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
   builtins_fetchurl = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
-      if lessThan nixVersion "1.12" then
-        fetchurl ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
-      else
-        fetchurl attrs;
+    if lessThan nixVersion "1.12" then
+      fetchurl ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
+    else
+      fetchurl attrs;
 
   # Create the final "sources" from the config
   mkSources = config:
-    mapAttrs (
-      name: spec:
-        if builtins.hasAttr "outPath" spec
-        then abort
-          "The values in sources.json should not have an 'outPath' attribute"
-        else
-          spec // { outPath = replace name (fetch config.pkgs name spec); }
-    ) config.sources;
+    mapAttrs
+      (
+        name: spec:
+          if builtins.hasAttr "outPath" spec
+          then
+            abort
+              "The values in sources.json should not have an 'outPath' attribute"
+          else
+            spec // { outPath = replace name (fetch config.pkgs name spec); }
+      )
+      config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
     { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
-    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
+    , sources ? if sourcesFile == null then { } else builtins.fromJSON (builtins.readFile sourcesFile)
     , system ? builtins.currentSystem
     , pkgs ? mkPkgs sources system
     }: rec {
@@ -173,4 +195,4 @@ let
     };
 
 in
-mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }
+mkSources (mkConfig { }) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -11,7 +11,7 @@ in
         # bundled with all the dependencies listed in `haskell-dependencies.nix`.
         # This allows us to have stack use the dependencies from nixpkgs,
         # instead of fetching them itself.
-        ghc = nixpkgs.Ghc902Packages.ghcWithPackages getDependencies;
+        ghc = nixpkgs.vaultenvHaskellPackages.ghcWithPackages getDependencies;
         buildInputs = with nixpkgs; [
           glibcLocales
         ];

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 # Changed the name here because nixpkgs also includes a vaultenv and we haven't
 # figured out how to mask that when we build vaultenv with nix itself.
 name: vaultenv-real
-version: 0.16.0
+version: 0.16.1
 synopsis: Runs processes with secrets from HashiCorp Vault
 license: BSD3
 github: channable/vaultenv
@@ -11,7 +11,7 @@ dependencies:
   - base
   - async
   - bytestring
-  - connection
+  - crypton-connection
   - containers
   - dotenv
   - directory

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Also take care to update the compiler in default.nix to the
 # compiler used in this Stackage snapshot.
-resolver: ghc-9.0.2
+resolver: ghc-9.6.4
 
 packages:
   - "."

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,4 +1,11 @@
-{ pkgs ? import ../nix/nixpkgs-pinned.nix {}
+{ pkgs ? import ../nix/nixpkgs-pinned.nix
+  # Allow vault to be used only as a part of this testing environment shell.
+  # We are not allowing the use of vault as a part of our final package
+  # because vault-1.16.1 is lisenced under BSL-1.1
+  { config.allowUnfreePredicate = pkg:
+      (pkgs.lib.getName pkg) == "vault" &&
+      (pkgs.lib.getVersion pkg) == "1.17.2";
+  }
 }:
   with pkgs; buildEnv {
     name = "vaultenv-testenv";

--- a/vaultenv.nix
+++ b/vaultenv.nix
@@ -10,7 +10,7 @@ let
 in
 mkDerivation {
   pname = "vaultenv";
-  version = "0.16.0";
+  version = "0.16.1";
 
   src =
     let


### PR DESCRIPTION
Seems like `crypton-connection` is superseding `connection`, and a large portion of the Haskell ecosystem has done the migration. Having both connection and crypton-connection in a project causes a conflict on the `tls` version.

Links:
- https://hackage.haskell.org/package/crypton-connection-0.3.1
- https://hackage.haskell.org/package/connection