### PR TITLE
Add an alias for '--secrets-file'

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,17 @@ of `tutorial.sh`.
 ```
 vaultenv 0.18.0 - run programs with secrets from HashiCorp Vault
 
-Usage: vaultenv [--version] [--host HOST] [--port PORT] [--addr ADDR]
-                [--token TOKEN | --github-token TOKEN | --kubernetes-role ROLE]
-                [--secrets-file FILENAME] [CMD] [ARGS...]
-                [--no-connect-tls | --connect-tls]
-                [--no-validate-certs | --validate-certs]
-                [--no-inherit-env | --inherit-env]
-                [--inherit-env-blacklist COMMA_SEPARATED_NAMES]
-                [--retry-base-delay-milliseconds MILLISECONDS]
-                [--retry-attempts NUM] [--log-level error | info] [--use-path]
-                [--max-concurrent-requests NUM]
+Usage: vaultenv [--version] [--host HOST] [--port PORT] [--addr ADDR] 
+                [--token TOKEN | --kubernetes-role ROLE | --github-token TOKEN] 
+                [--secrets-file FILENAME | --secret-file FILENAME] [CMD] 
+                [ARGS...] [--no-connect-tls | --connect-tls] 
+                [--no-validate-certs | --validate-certs] 
+                [--no-inherit-env | --inherit-env] 
+                [--inherit-env-blacklist COMMA_SEPARATED_NAMES] 
+                [--retry-base-delay-milliseconds MILLISECONDS] 
+                [--retry-attempts NUM] [--log-level error | info] [--use-path] 
+                [--max-concurrent-requests NUM] 
+                [--duplicate-variable-behavior error | keep | overwrite]
 
 Available options:
   -h,--help                Show this help text
@@ -126,13 +127,14 @@ Available options:
                            either VAULT_PORT or VAULT_HOST
   --token TOKEN            Token to authenticate to Vault with. Also
                            configurable via VAULT_TOKEN.
-  --github-token TOKEN     Authenticate using a GitHub personal access
-                           token. Also configurable via VAULTENV_GITHUB_TOKEN.
   --kubernetes-role ROLE   Authenticate using Kubernetes service account in
                            /var/run/secrets/kubernetes.io, with the given role.
                            Also configurable via VAULTENV_KUBERNETES_ROLE.
+  --github-token TOKEN     Authenticate using a GitHub personal access
+                           token.Also configurable via VAULTENV_GITHUB_TOKEN.
   --secrets-file FILENAME  Config file specifying which secrets to request. Also
                            configurable via VAULTENV_SECRETS_FILE.
+  --secret-file FILENAME   alias for `--secrets-file`
   CMD                      command to run after fetching secrets
   ARGS...                  Arguments to pass to CMD, defaults to nothing
   --no-connect-tls         Don't use TLS when connecting to Vault. Default: use

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -211,7 +211,7 @@ data OptionsError
   deriving (Eq)
 
 instance Show OptionsError where
-  show (UnspecifiedValue s) = "The option " ++ s ++ " is required but not specified"
+  show (UnspecifiedValue s) = "The option " ++ s ++ " is required but not specified. Run with --help for usage."
   show (URIParseError uri) = "The address" ++ show uri ++ " could not be parsed properly. Maybe the schema is missing?"
   show (UnknownScheme uri)  = "The address " ++ show uri ++ " has no recognisable scheme, "
       ++ " expected http:// or https:// at the beginning of the address."
@@ -300,8 +300,8 @@ mergeOptions opts1 opts2 = let
 isOptionsComplete :: Options Validated UnCompleted
                   -> Either [OptionsError] (Options Validated Completed)
 isOptionsComplete opts =
-      let errors = [UnspecifiedValue "Command" | isNothing (oCmd opts)]
-            ++ [UnspecifiedValue "Secret file" | isNothing (oSecretFile opts)]
+      let errors = [UnspecifiedValue "CMD" | isNothing (oCmd opts)]
+            ++ [UnspecifiedValue "--secrets-file" | isNothing (oSecretFile opts)]
       in  if not (null errors)
           then Left errors
           else Right (castOptions opts)
@@ -619,13 +619,22 @@ optionsParser = Options
 
     auth = token <|> kubernetesRole <|> githubToken <|> pure AuthNone
 
-    secretsFile
-      =  maybeStrOption
-      $  long "secrets-file"
-      <> metavar "FILENAME"
-      <> value Nothing
-      <> help ("Config file specifying which secrets to request. Also configurable " ++
-               "via VAULTENV_SECRETS_FILE." )
+    secretsFile = let
+        original
+          =  maybeStrOption
+          $  long "secrets-file"
+          <> metavar "FILENAME"
+          <> value Nothing
+          <> help ("Config file specifying which secrets to request. Also configurable " ++
+                   "via VAULTENV_SECRETS_FILE." )
+        alias
+          =  maybeStrOption
+          $  long "secret-file"
+          <> metavar "FILENAME"
+          <> value Nothing
+          <> help "alias for `--secrets-file`"
+      in original <|> alias
+
     cmd
       =  argument maybeStr
       $  metavar "CMD"


### PR DESCRIPTION
has this ever happened to you?

```
$ vaultenv -- echo "hello"
[ERROR] The option Secret file is required but not specified
$ vaultenv --secret-file foo.secrets -- echo "hello"
Invalid option `--secret-file'

Usage: vaultenv [--version] [--host HOST] [--port PORT] [--addr ADDR] 
                [--token TOKEN | --kubernetes-role ROLE | --github-token TOKEN] 
                [--secrets-file FILENAME] [CMD] [ARGS...] 
                [--no-connect-tls | --connect-tls] 
                [--no-validate-certs | --validate-certs] 
                [--no-inherit-env | --inherit-env] 
                [--inherit-env-blacklist COMMA_SEPARATED_NAMES] 
                [--retry-base-delay-milliseconds MILLISECONDS] 
                [--retry-attempts NUM] [--log-level error | info] [--use-path] 
                [--max-concurrent-requests NUM] 
                [--duplicate-variable-behavior error | keep | overwrite]
```

i also took the liberty of improving the "unspecified value" error message a little to mention the part of the USAGE that's missing directly