### PR TITLE
CI: build vaultenv on MacOS

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -64,3 +64,47 @@ blocks:
             # Store a copy of the nix store. This will be refreshed daily, which
             # is more than sufficient for this repo.
             - "cache store nix-store-$(date -u -Idate) /nix"
+
+
+  - name: "Build on MacOS"
+    task:
+      agent:
+        machine:
+          type: a2-standard-4
+          os_image: macos-xcode26
+
+      secrets:
+        # Keys needed to access our cachix cache.
+        - name: "cachix-channable-public"
+
+      jobs:
+        - name: "Build on MacOS"
+          commands:
+            - "checkout"
+
+            # Download and verify Nix installation script.
+            - curl -o install-nix-2.24.12 https://releases.nixos.org/nix/nix-2.24.12/install
+            - sha256sum --check .semaphore/install-nix.sha256
+
+            # Install Nix
+            - "yes | sh ./install-nix-2.24.12 --daemon-user-count 2"
+            - "echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf"
+            - "echo 'max-jobs = auto' | sudo tee -a /etc/nix/nix.conf"
+            - "echo 'trusted-users = root semaphore' | sudo tee -a /etc/nix/nix.conf"
+            - "sudo launchctl kickstart -k system/org.nixos.nix-daemon"
+
+            # Ensure necessary environment variables are set
+            - ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+
+            # This prevent `nix profile install` from failing
+            - "sudo chmod 755 /nix/var/nix/profiles/per-user"
+
+            # Install and configure Cachix.
+            - "nix profile install nixpkgs#cachix"
+            - "cachix use channable-public"
+
+            # Build the devenv and the static package
+            - "nix-build --no-out-link default.nix nix/release.nix > nix-store-locations"
+
+            # push the result to Cachix.
+            - "cat nix-store-locations | cachix push channable-public"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,3 +10,5 @@
  1. Go to https://github.com/channable/vaultenv/releases
  1. Click "Draft a new release". Add the binary from the Nix output and the
     .deb package.
+ 1. Go to the MacOS build in CI, copy the store path and `nix-store --realize` the path
+ 1. Upload the binary in this store path as `vaultenv-<version>-darwin`

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -3,8 +3,8 @@ let
 in {
   # Normal cabal build where Nix handles dependencies.
   vaultenv = pkgs.haskellPackages.callPackage ../vaultenv.nix {};
-
-  # Static package build
+} // pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+  # Static package build. This only works on Linux, musl doesn't support Darwin
   vaultenvStatic = (pkgs.pkgsStatic.haskellPackages.callPackage ../vaultenv.nix {
     # Use non-static version of glibc locales, as the static version fails to build.
     glibcLocales = pkgs.glibcLocales;


### PR DESCRIPTION
Add a CI step to build `vaultenv` on MacOS. We cannot build the static (musl) binary on MacOS, as musl simply doesn't support it.

I'll upload the binary in the current release, as there are no code changes